### PR TITLE
Add throughput stats for pcie inline with rdc

### DIFF
--- a/sw/nic/gpuagent/api/include/aga_gpu.hpp
+++ b/sw/nic/gpuagent/api/include/aga_gpu.hpp
@@ -499,6 +499,10 @@ typedef struct aga_gpu_pcie_stats_s {
     uint64_t nack_sent_count;
     /// total number of NACKs issued on the PCIe link by the receiver
     uint64_t nack_received_count;
+    /// accumulated bytes received from the PCIe link
+    uint64_t rx_bytes;
+    /// accumulated bytes transmitted to the PCIe link
+    uint64_t tx_bytes;
 } aga_gpu_pcie_stats_t;
 
 /// \brief GPU voltage statistics

--- a/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
+++ b/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
@@ -39,6 +39,7 @@ namespace aga {
 #define AMDSMI_INVALID_PARTITION_COUNT  0xffff
 #define AMDSMI_INVALID_UINT16           0xffff
 #define AMDSMI_INVALID_UINT32           0xffffffff
+#define AMDSMI_INVALID_UINT64           0xffffffffffffffff
 #define AMDSMI_DEEP_SLEEP_THRESHOLD     140
 #define AMDSMI_COUNTER_RESOLUTION       15.3
 
@@ -1009,6 +1010,7 @@ smi_gpu_fill_stats (aga_gpu_handle_t gpu_handle,
                     aga_gpu_stats_t *stats)
 {
     amdsmi_status_t amdsmi_ret;
+    uint64_t sent, received, max_pkt_size;
     amdsmi_gpu_metrics_t metrics_info = {};
 
     // fill VRAM usage
@@ -1103,6 +1105,20 @@ smi_gpu_fill_stats (aga_gpu_handle_t gpu_handle,
             metrics_info.pcie_nak_sent_count_acc;
         stats->pcie_stats.nack_received_count =
             metrics_info.pcie_nak_rcvd_count_acc;
+
+        // PCIe throughput initialization to invalid value
+        stats->pcie_stats.tx_bytes = AMDSMI_INVALID_UINT64;
+        stats->pcie_stats.rx_bytes = AMDSMI_INVALID_UINT64;
+
+        amdsmi_ret = amdsmi_get_gpu_pci_throughput(gpu_handle, &sent, &received,
+                                                   &max_pkt_size);
+        if (unlikely(amdsmi_ret != AMDSMI_STATUS_SUCCESS)) {
+            AGA_TRACE_ERR("Failed to get PCIe throughput for GPU {}, err {}",
+                          gpu_handle, amdsmi_ret);
+        } else {
+            stats->pcie_stats.tx_bytes = received;
+            stats->pcie_stats.rx_bytes = sent;
+        }
     } else {
         AGA_TRACE_ERR("Failed to get GPU metrics info for GPU {}, err {}",
                       gpu_handle, amdsmi_ret);

--- a/sw/nic/gpuagent/api/smi/smi_api_mock.cc
+++ b/sw/nic/gpuagent/api/smi/smi_api_mock.cc
@@ -259,6 +259,15 @@ smi_gpu_fill_stats (aga_gpu_handle_t gpu_handle,
     stats->vram_usage.used_gtt = 20;
     stats->vram_usage.free_gtt =
         stats->vram_usage.total_gtt - stats->vram_usage.used_gtt;
+    // fill the PCIe stats
+    ++stats->pcie_stats.replay_count;
+    ++stats->pcie_stats.tx_bytes;
+    ++stats->pcie_stats.recovery_count;
+    ++stats->pcie_stats.replay_rollover_count;
+    ++stats->pcie_stats.nack_sent_count;
+    ++stats->pcie_stats.nack_received_count;
+    ++stats->pcie_stats.rx_bytes;
+    ++stats->pcie_stats.tx_bytes;
     // fill the energy consumed
     stats->energy_consumed = 25293978861568 + distr(gen) - distr(gen);
     for (uint16_t i = 0; i < AMDSMI_MAX_NUM_XCC; i++) {

--- a/sw/nic/gpuagent/cli/cmd/gpu.go
+++ b/sw/nic/gpuagent/cli/cmd/gpu.go
@@ -1170,6 +1170,16 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 			fmt.Printf(indent+"  %-36s : %d\n", "NACKs received",
 				p.GetNACKReceivedCount())
 		}
+		if p.GetRxBytes() != UINT64_MAX_VAL {
+			printPCIeStatusHdr(indent)
+			fmt.Printf(indent+"  %-36s : %d\n", "Total received bytes",
+				p.GetRxBytes())
+		}
+		if p.GetTxBytes() != UINT64_MAX_VAL {
+			printPCIeStatusHdr(indent)
+			fmt.Printf(indent+"  %-36s : %d\n", "Total transmitted bytes",
+				p.GetTxBytes())
+		}
 	}
 	if stats.GetVRAMUsage() != nil {
 		printHdr = false

--- a/sw/nic/gpuagent/protos/gpu.proto
+++ b/sw/nic/gpuagent/protos/gpu.proto
@@ -473,6 +473,10 @@ message GPUPCIeStats {
   uint64 NACKSentCount       = 4;
   // total number of NACKs issued on the PCIe link by the receiver
   uint64 NACKReceivedCount   = 5;
+  // accumulated bytes received from the PCIe link
+  uint64       RxBytes       = 6;
+  // accumulated bytes transmitted to the PCIe link
+  uint64       TxBytes       = 7;
 }
 
 // voltage statistics

--- a/sw/nic/gpuagent/svc/gpu_to_proto.hpp
+++ b/sw/nic/gpuagent/svc/gpu_to_proto.hpp
@@ -533,6 +533,8 @@ aga_gpu_pcie_stats_to_proto (GPUPCIeStats *proto_stats,
     proto_stats->set_replayrollovercount(stats->replay_rollover_count);
     proto_stats->set_nacksentcount(stats->nack_sent_count);
     proto_stats->set_nackreceivedcount(stats->nack_received_count);
+    proto_stats->set_rxbytes(stats->rx_bytes);
+    proto_stats->set_txbytes(stats->tx_bytes);
 }
 
 // populte VRAM usage stats proto


### PR DESCRIPTION
cp of pensando/sw#103082

Currently none of the platform seem to support it, we have integrated so when driver is ready it should work with the api provided.

```bash
$ amd-smi metric --pcie | grep -e BANDWIDTH_SENT -e BANDWIDTH_RECEI 

CURRENT_BANDWIDTH_SENT: N/A
CURRENT_BANDWIDTH_RECEIVED: N/A
```