### PR TITLE
Issue reported : ROCm/device-metrics-exporter#176

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 sw/nic/build/
 sw/nic/build*
 sw/nic/third-party/libev-4.33/*
+sw/nic/gpuagent/vendor

--- a/sw/nic/gpuagent/Makefile
+++ b/sw/nic/gpuagent/Makefile
@@ -169,6 +169,15 @@ $(TARGET)_gim: build-libs gogo-protos gen-protos $(OBJ_GIM)
 	$(CC) $(OBJ_GIM) $(LDFLAGS_GIM_SMI) -o $(BLD_BIN_DIR)/$(TARGET)_gim
 	${MAKE} gpuctl
 
+.PHONY: mod
+mod:
+	@go mod tidy
+	@go mod edit -go=1.24.6
+	#CVE-2024-24790 - gpuctl
+	@go mod edit -replace golang.org/x/net@v0.30.0=golang.org/x/net@v0.38.0
+	@go mod vendor
+
+
 .PHONY: all
 all: build-libs gogo-protos gen-protos $(OBJ) $(OBJ_GIM) $(OBJ_MOCK)
 	mkdir -p $(BLD_BIN_DIR)

--- a/sw/nic/gpuagent/go.mod
+++ b/sw/nic/gpuagent/go.mod
@@ -1,6 +1,6 @@
 module github.com/ROCm/gpu-agent/sw/nic/gpuagent
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/gogo/protobuf v1.3.2
@@ -19,3 +19,5 @@ require (
 	golang.org/x/text v0.25.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 // indirect
 )
+
+replace golang.org/x/net v0.30.0 => golang.org/x/net v0.38.0

--- a/sw/nic/gpuagent/go.sum
+++ b/sw/nic/gpuagent/go.sum
@@ -25,8 +25,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.30.0 h1:AcW1SDZMkb8IpzCdQUaIq2sP4sZ4zw+55h6ynffypl4=
-golang.org/x/net v0.30.0/go.mod h1:2wGyMJ5iFasEhkwi13ChkO/t1ECNC4X4eBKkVFyYFlU=
+golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
+golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/tools/build-container/Dokerfile.rhel9
+++ b/tools/build-container/Dokerfile.rhel9
@@ -28,9 +28,9 @@ RUN dnf install -y --allowerasing \
 
 RUN yum install -y sudo
 
-RUN wget https://go.dev/dl/go1.24.4.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.24.4.linux-amd64.tar.gz && \
-    rm -f go1.24.4.linux-amd64.tar.gz
+RUN wget https://go.dev/dl/go1.24.6.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.24.6.linux-amd64.tar.gz && \
+    rm -f go1.24.6.linux-amd64.tar.gz
 
 ENV PATH=$PATH:/usr/local/go/bin:/root/go/bin
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH

--- a/tools/build-container/Dokerfile.ubu2204
+++ b/tools/build-container/Dokerfile.ubu2204
@@ -30,9 +30,9 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /usr/src/github.com/Rocm/gpu-agent/
 
-RUN wget https://go.dev/dl/go1.24.4.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.24.4.linux-amd64.tar.gz && \
-    rm -f go1.24.4.linux-amd64.tar.gz
+RUN wget https://go.dev/dl/go1.24.6.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.24.6.linux-amd64.tar.gz && \
+    rm -f go1.24.6.linux-amd64.tar.gz
 
 ADD ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
This PR addresses a HIGH severity security vulnerability (CVE-2025-47907) identified by the security team in our Go binaries. The vulnerability affects the Go standard library v1.24.4 and involves improper handling of query cancellation in database drivers, which could lead to unexpected behavior when contexts are cancelled.

Issue Reported: ROCm/device-metrics-exporter#176