### PR TITLE
Add PCIe accumulated bandwidth stats #103349

### DIFF
--- a/sw/nic/gpuagent/api/include/aga_gpu.hpp
+++ b/sw/nic/gpuagent/api/include/aga_gpu.hpp
@@ -503,6 +503,8 @@ typedef struct aga_gpu_pcie_stats_s {
     uint64_t rx_bytes;
     /// accumulated bytes transmitted to the PCIe link
     uint64_t tx_bytes;
+    /// accumulated combined bandwidth on PCIe link (GB/sec)
+    uint64_t bidir_bandwidth;
 } aga_gpu_pcie_stats_t;
 
 /// \brief GPU voltage statistics

--- a/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
+++ b/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
@@ -1105,6 +1105,8 @@ smi_gpu_fill_stats (aga_gpu_handle_t gpu_handle,
             metrics_info.pcie_nak_sent_count_acc;
         stats->pcie_stats.nack_received_count =
             metrics_info.pcie_nak_rcvd_count_acc;
+        stats->pcie_stats.bidir_bandwidth =
+            metrics_info.pcie_bandwidth_acc;
 
         // PCIe throughput initialization to invalid value
         stats->pcie_stats.tx_bytes = AMDSMI_INVALID_UINT64;

--- a/sw/nic/gpuagent/api/smi/smi_api_mock.cc
+++ b/sw/nic/gpuagent/api/smi/smi_api_mock.cc
@@ -268,6 +268,7 @@ smi_gpu_fill_stats (aga_gpu_handle_t gpu_handle,
     ++stats->pcie_stats.nack_received_count;
     ++stats->pcie_stats.rx_bytes;
     ++stats->pcie_stats.tx_bytes;
+    ++stats->pcie_stats.bidir_bandwidth;
     // fill the energy consumed
     stats->energy_consumed = 25293978861568 + distr(gen) - distr(gen);
     for (uint16_t i = 0; i < AMDSMI_MAX_NUM_XCC; i++) {

--- a/sw/nic/gpuagent/cli/cmd/gpu.go
+++ b/sw/nic/gpuagent/cli/cmd/gpu.go
@@ -1171,14 +1171,20 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 				p.GetNACKReceivedCount())
 		}
 		if p.GetRxBytes() != UINT64_MAX_VAL {
-			printPCIeStatusHdr(indent)
+			printPCIeHdr(indent)
 			fmt.Printf(indent+"  %-36s : %d\n", "Total received bytes",
 				p.GetRxBytes())
 		}
 		if p.GetTxBytes() != UINT64_MAX_VAL {
-			printPCIeStatusHdr(indent)
+			printPCIeHdr(indent)
 			fmt.Printf(indent+"  %-36s : %d\n", "Total transmitted bytes",
 				p.GetTxBytes())
+		}
+		if p.GetBiDirBandwidth() != UINT16_MAX_VAL_UINT64 {
+			printPCIeHdr(indent)
+			fmt.Printf(indent+"  %-36s : %d\n",
+				"Bidirectional bandwidth (in GB/s)",
+				p.GetBiDirBandwidth())
 		}
 	}
 	if stats.GetVRAMUsage() != nil {

--- a/sw/nic/gpuagent/protos/gpu.proto
+++ b/sw/nic/gpuagent/protos/gpu.proto
@@ -474,9 +474,11 @@ message GPUPCIeStats {
   // total number of NACKs issued on the PCIe link by the receiver
   uint64 NACKReceivedCount   = 5;
   // accumulated bytes received from the PCIe link
-  uint64       RxBytes       = 6;
+  uint64 RxBytes             = 6;
   // accumulated bytes transmitted to the PCIe link
-  uint64       TxBytes       = 7;
+  uint64 TxBytes             = 7;
+  // bidirectional accumulated bandwidth on PCIe (GB/sec)
+  uint64 BiDirBandwidth      = 8;
 }
 
 // voltage statistics

--- a/sw/nic/gpuagent/svc/gpu_to_proto.hpp
+++ b/sw/nic/gpuagent/svc/gpu_to_proto.hpp
@@ -535,6 +535,7 @@ aga_gpu_pcie_stats_to_proto (GPUPCIeStats *proto_stats,
     proto_stats->set_nackreceivedcount(stats->nack_received_count);
     proto_stats->set_rxbytes(stats->rx_bytes);
     proto_stats->set_txbytes(stats->tx_bytes);
+    proto_stats->set_bidirbandwidth(stats->bidir_bandwidth);
 }
 
 // populte VRAM usage stats proto


### PR DESCRIPTION
cherry-pick of pensando/sw#103349

HW doesn't support individual rx tx but does have combined counter for the current platforms.
Exposing accumulated pcie bandwidth to better understanding on behavior for usable metrics.

```bash
[root@gpu-operator-metrics-exporter-qmn2l ~]# ./gpuctl.gobin show gpu all | grep -i Bandwidth
    Current bandwidth (in MB/s)          : 18
    Bidirectional bandwidth (in GB/s)    : 712136650951
    Current bandwidth (in MB/s)          : 18
    Bidirectional bandwidth (in GB/s)    : 704701205332
    Current bandwidth (in MB/s)          : 18
    Bidirectional bandwidth (in GB/s)    : 718566671110
    Current bandwidth (in MB/s)          : 18
    Bidirectional bandwidth (in GB/s)    : 730175287429
    Current bandwidth (in MB/s)          : 18
    Bidirectional bandwidth (in GB/s)    : 735069263592
    Current bandwidth (in MB/s)          : 3144
    Bidirectional bandwidth (in GB/s)    : 839342269626
    Current bandwidth (in MB/s)          : 18
    Bidirectional bandwidth (in GB/s)    : 729410893863
    Current bandwidth (in MB/s)          : 18
    Bidirectional bandwidth (in GB/s)    : 7820900115626


prshanmug@mi325x8-110:~/exporter$ rocm-smi --showmetrics | grep  pcie_bandwidth_
GPU[0]          : pcie_bandwidth_acc (GB/s): 7821031975677
GPU[0]          : pcie_bandwidth_inst (GB/s): 10325
GPU[1]          : pcie_bandwidth_acc (GB/s): 839414369869
GPU[1]          : pcie_bandwidth_inst (GB/s): 3564
GPU[2]          : pcie_bandwidth_acc (GB/s): 735069793614
GPU[2]          : pcie_bandwidth_inst (GB/s): 18
GPU[3]          : pcie_bandwidth_acc (GB/s): 730175826194
GPU[3]          : pcie_bandwidth_inst (GB/s): 18
GPU[4]          : pcie_bandwidth_acc (GB/s): 729411434248
GPU[4]          : pcie_bandwidth_inst (GB/s): 18
GPU[5]          : pcie_bandwidth_acc (GB/s): 704701741191
GPU[5]          : pcie_bandwidth_inst (GB/s): 18
GPU[6]          : pcie_bandwidth_acc (GB/s): 712137192451
GPU[6]          : pcie_bandwidth_inst (GB/s): 18
GPU[7]          : pcie_bandwidth_acc (GB/s): 718567212884
GPU[7]          : pcie_bandwidth_inst (GB/s): 18


```