### PR TITLE
cp pensando/sw/#103674

### DIFF
--- a/sw/nic/gpuagent/api/gpu.hpp
+++ b/sw/nic/gpuagent/api/gpu.hpp
@@ -187,6 +187,18 @@ public:
         return partition_id_;
     }
 
+    /// \brief  set GPU virtualization mode
+    /// \param[in] virtualization mode
+    void set_virtualization_mode(aga_gpu_virtualization_mode_t mode) {
+        virtualization_mode_ = mode;
+    }
+
+    /// \brief  return GPU virtualization mode
+    /// \return virtualization mode
+    aga_gpu_virtualization_mode_t virtualization_mode(void) {
+        return virtualization_mode_;
+    }
+
     /// \brief  check if GPU is a child
     /// \return true if child GPU, false otherwise
     bool is_child_gpu(void) {
@@ -317,6 +329,8 @@ private:
     aga_gpu_status_t status_;
     /// GPU watch stats
     aga_gpu_watch_fields_t stats_;
+    /// GPU virtualization mode;
+    aga_gpu_virtualization_mode_t virtualization_mode_;
     /// number of GPU watch objects watching this GPU
     uint32_t num_gpu_watch_;
     /// a friend of gpu entry

--- a/sw/nic/gpuagent/api/include/aga_gpu.hpp
+++ b/sw/nic/gpuagent/api/include/aga_gpu.hpp
@@ -414,6 +414,16 @@ typedef struct aga_gpu_bad_page_record_s {
     aga_gpu_page_status_t page_status;
 } aga_gpu_bad_page_record_t;
 
+/// \brief GPU virtualization mode
+typedef enum aga_gpu_virtualization_mode_e {
+    AGA_VIRTUALIZATION_MODE_NONE        = 0,
+    AGA_VIRTUALIZATION_MODE_UNKNOWN     = AGA_VIRTUALIZATION_MODE_NONE,
+    AGA_VIRTUALIZATION_MODE_BAREMETAL   = 1,
+    AGA_VIRTUALIZATION_MODE_HOST        = 2,
+    AGA_VIRTUALIZATION_MODE_GUEST       = 3,
+    AGA_VIRTUALIZATION_MODE_PASSTHROUGH = 4,
+} aga_gpu_virtualization_mode_t;
+
 /// \brief operational information of a physical GPU
 typedef struct aga_gpu_status_s {
     /// assigned GPU index local to compute node
@@ -485,6 +495,8 @@ typedef struct aga_gpu_status_s {
     uint32_t drm_render_id;
     // GPU driver DRM card id
     uint32_t drm_card_id;
+    // GPU virtualization mode
+    aga_gpu_virtualization_mode_t virtualization_mode;
 } aga_gpu_status_t;
 
 /// \brief GPU PCIe statistics

--- a/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
+++ b/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
@@ -1629,6 +1629,7 @@ smi_gpu_init_immutable_attrs (aga_gpu_handle_t gpu_handle, aga_gpu_spec_t *spec,
     amdsmi_vbios_info_t vbios_info;
     amdsmi_board_info_t board_info;
     amdsmi_driver_info_t driver_info;
+    amdsmi_virtualization_mode_t mode;
 
     // fill immutable attributes in spec
     // fill gpu and memory clock frequencies
@@ -1640,6 +1641,14 @@ smi_gpu_init_immutable_attrs (aga_gpu_handle_t gpu_handle, aga_gpu_spec_t *spec,
     if (unlikely(amdsmi_ret != AMDSMI_STATUS_SUCCESS)) {
        AGA_TRACE_ERR("Failed to get serial number for GPU {}, err {}",
                      gpu_handle, amdsmi_ret);
+    }
+    // fill the virtualization mode
+    amdsmi_ret = amdsmi_get_gpu_virtualization_mode(gpu_handle, &mode);
+    if (unlikely(amdsmi_ret != AMDSMI_STATUS_SUCCESS)) {
+        AGA_TRACE_ERR("Failed to get virtualization mode for GPU {}, err {}",
+                      gpu_handle, amdsmi_ret);
+    } else {
+        status->virtualization_mode = smi_to_aga_virtualization_mode(mode);
     }
     memcpy(status->serial_num, board_info.product_serial, AGA_MAX_STR_LEN);
     // fill the GPU card series

--- a/sw/nic/gpuagent/api/smi/amdsmi/smi_utils.hpp
+++ b/sw/nic/gpuagent/api/smi/amdsmi/smi_utils.hpp
@@ -76,6 +76,25 @@ find_low_high_frequency (amdsmi_frequencies_t *freq,
     return;
 }
 
+/// \brief convert amdsmi virtualization mode to aga vritualization mode
+/// \param[in] virt_mode    amdsmi virtualization mode
+/// \return    aga virtualization mode
+static inline aga_gpu_virtualization_mode_t
+smi_to_aga_virtualization_mode (amdsmi_virtualization_mode_t virt_mode)
+{
+    switch (virt_mode) {
+    case AMDSMI_VIRTUALIZATION_MODE_HOST:
+        return AGA_VIRTUALIZATION_MODE_HOST;
+    case AMDSMI_VIRTUALIZATION_MODE_GUEST:
+        return AGA_VIRTUALIZATION_MODE_GUEST;
+    case AMDSMI_VIRTUALIZATION_MODE_PASSTHROUGH:
+        return AGA_VIRTUALIZATION_MODE_PASSTHROUGH;
+    default:
+        break;
+    }
+    return AGA_VIRTUALIZATION_MODE_UNKNOWN;
+}
+
 /// \brief convert amdsmi VRAM type to aga VRAM type
 /// \param[in] vram_type    amdsmi VRAM type
 /// \return    aga VRAM type

--- a/sw/nic/gpuagent/api/smi/gimamdsmi/smi_api.cc
+++ b/sw/nic/gpuagent/api/smi/gimamdsmi/smi_api.cc
@@ -1067,6 +1067,7 @@ smi_gpu_init_immutable_attrs (aga_gpu_handle_t gpu_handle, aga_gpu_spec_t *spec,
     amdsmi_vbios_info_t vbios_info;
     amdsmi_board_info_t board_info;
     amdsmi_driver_info_t driver_info;
+    amdsmi_virtualization_mode_t mode;
 
     // fill immutable attributes in spec
     // fill gpu and memory clock frequencies
@@ -1079,6 +1080,16 @@ smi_gpu_init_immutable_attrs (aga_gpu_handle_t gpu_handle, aga_gpu_spec_t *spec,
        AGA_TRACE_ERR("Failed to get serial number for GPU {}, err {}",
                      gpu_handle, amdsmi_ret);
     }
+
+    // fill the virtualization mode
+    amdsmi_ret = amdsmi_get_gpu_virtualization_mode(gpu_handle, &mode);
+    if (unlikely(amdsmi_ret != AMDSMI_STATUS_SUCCESS)) {
+        AGA_TRACE_ERR("Failed to get virtualization mode for GPU {}, err {}",
+                      gpu_handle, amdsmi_ret);
+    } else {
+        status->virtualization_mode = smi_to_aga_virtualization_mode(mode);
+    }
+
     memcpy(status->serial_num, board_info.product_serial, AGA_MAX_STR_LEN);
     // fill the GPU card series
     memcpy(status->card_series, board_info.product_name, AGA_MAX_STR_LEN);

--- a/sw/nic/gpuagent/api/smi/gimamdsmi/smi_utils.hpp
+++ b/sw/nic/gpuagent/api/smi/gimamdsmi/smi_utils.hpp
@@ -80,6 +80,25 @@ smi_to_aga_vram_type (amdsmi_vram_type_t vram_type)
     return AGA_VRAM_TYPE_NONE;
 }
 
+/// \brief convert amdsmi virtualization mode to aga vritualization mode
+/// \param[in] virt_mode    amdsmi virtualization mode
+/// \return    aga virtualization mode
+static inline aga_gpu_virtualization_mode_t
+smi_to_aga_virtualization_mode (amdsmi_virtualization_mode_t virt_mode)
+{
+    switch (virt_mode) {
+    case AMDSMI_VIRTUALIZATION_MODE_HOST:
+        return AGA_VIRTUALIZATION_MODE_HOST;
+    case AMDSMI_VIRTUALIZATION_MODE_GUEST:
+        return AGA_VIRTUALIZATION_MODE_GUEST;
+    case AMDSMI_VIRTUALIZATION_MODE_PASSTHROUGH:
+        return AGA_VIRTUALIZATION_MODE_PASSTHROUGH;
+    default:
+        break;
+    }
+    return AGA_VIRTUALIZATION_MODE_UNKNOWN;
+}
+
 /// \brief convert amdsmi VRAM vendor to aga VRAM vendor
 /// \param[in] vendor    amdsmi vendor
 /// \return    aga vendor

--- a/sw/nic/gpuagent/api/smi/smi_api_mock.cc
+++ b/sw/nic/gpuagent/api/smi/smi_api_mock.cc
@@ -616,6 +616,14 @@ smi_get_gpu_partition_id (aga_gpu_handle_t gpu_handle, uint32_t *partition_id)
 }
 
 sdk_ret_t
+smi_get_gpu_virtualization_mode (aga_gpu_handle_t gpu_handle,
+                                 aga_gpu_virtualization_mode_t *mode)
+{
+    *mode = AGA_VIRTUALIZATION_MODE_BAREMETAL;
+    return SDK_RET_OK;
+}
+
+sdk_ret_t
 smi_get_gpu_partition_info (aga_gpu_handle_t gpu_handle, bool *capable,
                             aga_gpu_compute_partition_type_t *compute_partition,
                             aga_gpu_memory_partition_type_t *memory_partition)

--- a/sw/nic/gpuagent/cli/cmd/gpu.go
+++ b/sw/nic/gpuagent/cli/cmd/gpu.go
@@ -692,6 +692,9 @@ func printGPUStatus(gpu *aga.GPU, statusOnly bool) {
 	fmt.Printf(indent+"%-38s : %d\n", "KFD id", status.GetKFDId())
 	fmt.Printf(indent+"%-38s : %d\n", "DRM render id", status.GetDRMRenderId())
 	fmt.Printf(indent+"%-38s : %d\n", "DRM card id", status.GetDRMCardId())
+	fmt.Printf(indent+"%-38s : %s\n", "Virtualization mode",
+	    strings.ToLower(strings.Replace(status.GetVirtualizationMode().String(),
+				"GPU_VIRTUALIZATION_MODE_", "", -1)))
 	fmt.Printf(indent+"%-38s : 0x%x\n", "GPU handle", status.GetGPUHandle())
 	if status.GetSerialNum() != "" {
 		fmt.Printf(indent+"%-38s : %s\n", "Serial number",

--- a/sw/nic/gpuagent/protos/gpu.proto
+++ b/sw/nic/gpuagent/protos/gpu.proto
@@ -151,6 +151,20 @@ enum GPUMemoryPartitionType {
   GPU_MEMORY_PARTITION_TYPE_NPS8 = 4;
 }
 
+// GPU virtualization mode
+enum GPUVirtualizationMode {
+  // none unknown/invalid virtualization type
+  GPU_VIRTUALIZATION_MODE_NONE        = 0;
+  // baremetal virtualization type
+  GPU_VIRTUALIZATION_MODE_BAREMETAL   = 1;
+  // host virtualization type
+  GPU_VIRTUALIZATION_MODE_HOST        = 2;
+  // guest virtualization type
+  GPU_VIRTUALIZATION_MODE_GUEST       = 3;
+  // passthrough virtualization type
+  GPU_VIRTUALIZATION_MODE_PASSTHROUGH = 4;
+}
+
 // config specification of physical GPU
 message GPUSpec {
   // uuid identifying the GPU
@@ -355,65 +369,67 @@ message GPUBadPageGetResponse {
 // operational information of a physical GPU
 message GPUStatus {
   // assigned GPU index local to the compute node
-  uint32                        Index             = 1;
+  uint32                      Index              = 1;
   // GPU handle
-  uint64                        GPUHandle         = 2;
+  uint64                      GPUHandle          = 2;
   // serial number of the GPU
-  string                        SerialNum         = 3;
+  string                      SerialNum          = 3;
   // product series of the GPU
-  string                        CardSeries        = 4;
+  string                      CardSeries         = 4;
   // model of the GPU
-  string                        CardModel         = 5;
+  string                      CardModel          = 5;
   // GPU vendor
-  string                        CardVendor        = 6;
+  string                      CardVendor         = 6;
   // SKU of the GPU card
-  string                        CardSKU           = 7;
+  string                      CardSKU            = 7;
   // operational status of the device
-  GPUOperStatus                 OperStatus        = 8;
+  GPUOperStatus               OperStatus         = 8;
   // driver version
-  string                        DriverVersion     = 9;
+  string                      DriverVersion      = 9;
   // VBIOS part number
-  string                        VBIOSPartNumber   = 10;
+  string                      VBIOSPartNumber    = 10;
   // VBIOS version
-  string                        VBIOSVersion      = 11;
+  string                      VBIOSVersion       = 11;
   // firmware versions of various components
-  repeated GPUFirmwareVersion   FirmwareVersion   = 12;
+  repeated GPUFirmwareVersion FirmwareVersion    = 12;
   // memory component vendor
-  string                        MemoryVendor      = 13;
+  string                      MemoryVendor       = 13;
   // GPU clock status
-  repeated GPUClockStatus       ClockStatus       = 14;
+  repeated GPUClockStatus     ClockStatus        = 14;
   // Kernel Fusion Driver (KFD) process ids using the GPU
-  repeated uint32               KFDProcessId      = 15;
+  repeated uint32             KFDProcessId       = 15;
   // RAS (Reliability, Availability & Serviceability) information
-  GPURASStatus                  RASStatus         = 16;
+  GPURASStatus                RASStatus          = 16;
   // XGMI status
-  GPUXGMIStatus                 XGMIStatus        = 17;
+  GPUXGMIStatus               XGMIStatus         = 17;
   // VRAM status
-  GPUVRAMStatus                 VRAMStatus        = 18;
+  GPUVRAMStatus               VRAMStatus         = 18;
   // PCIe status
-  GPUPCIeStatus                 PCIeStatus        = 19;
+  GPUPCIeStatus               PCIeStatus         = 19;
   // throttling status
-  GPUThrottlingStatus           ThrottlingStatus  = 20;
+  GPUThrottlingStatus         ThrottlingStatus   = 20;
   // firmware timestamp in ns (10ns resolution)
-  uint64                        FWTimestamp       = 21;
+  uint64                      FWTimestamp        = 21;
   // GPU compute partition id; only valid when partition type is not SPX
-  uint32                        PartitionId       = 22;
+  uint32                      PartitionId        = 22;
   // GPU partitions (aka. child GPUs)
   // NOTE:
   // only valid for physical GPUs which have been partitioned
-  repeated bytes                GPUPartition      = 23;
+  repeated bytes              GPUPartition       = 23;
   // physical GPU (aka. parent GPU)
   // NOTE:
   // only valid for GPU partitions (child GPUs)
-  bytes                         PhysicalGPU       = 24;
+  bytes                       PhysicalGPU        = 24;
   // GPU KFD id
-  uint64                        KFDId             = 25;
+  uint64                      KFDId              = 25;
   // GPU node id
-  uint32                        NodeId            = 26;
+  uint32                      NodeId             = 26;
   // GPU device DRM render Id
-  uint32                        DRMRenderId       = 27;
+  uint32                      DRMRenderId        = 27;
   // GPU device DRM  card Id
-  uint32                        DRMCardId         = 28;
+  uint32                      DRMCardId          = 28;
+  // GPU virtualization mode
+  GPUVirtualizationMode       VirtualizationMode = 29;
 
 }
 

--- a/sw/nic/gpuagent/svc/gpu_to_proto.hpp
+++ b/sw/nic/gpuagent/svc/gpu_to_proto.hpp
@@ -112,6 +112,24 @@ aga_gpu_throttling_status_to_proto (aga_gpu_throttling_status_t status)
     return amdgpu::GPU_THROTTLING_STATUS_NONE;
 }
 
+static inline amdgpu::GPUVirtualizationMode
+aga_gpu_virtualization_mode_to_proto (aga_gpu_virtualization_mode_t mode)
+{
+    switch (mode) {
+    case AGA_VIRTUALIZATION_MODE_BAREMETAL:
+        return amdgpu::GPU_VIRTUALIZATION_MODE_BAREMETAL;
+    case AGA_VIRTUALIZATION_MODE_HOST:
+        return amdgpu::GPU_VIRTUALIZATION_MODE_HOST;
+    case AGA_VIRTUALIZATION_MODE_GUEST:
+        return amdgpu::GPU_VIRTUALIZATION_MODE_GUEST;
+    case AGA_VIRTUALIZATION_MODE_PASSTHROUGH:
+        return amdgpu::GPU_VIRTUALIZATION_MODE_PASSTHROUGH;
+    default:
+        break;
+    }
+    return amdgpu::GPU_VIRTUALIZATION_MODE_NONE;
+}
+
 static inline void
 aga_gpu_clock_spec_to_proto (GPUClockFrequencyRange *proto_spec,
                              const aga_gpu_clock_freq_range_t *spec)
@@ -394,6 +412,8 @@ aga_gpu_api_status_to_proto (GPUStatus *proto_status,
                                           status->throttling_status));
     proto_status->set_fwtimestamp(status->fw_timestamp);
     proto_status->set_partitionid(status->partition_id);
+    proto_status->set_virtualizationmode(aga_gpu_virtualization_mode_to_proto(
+                                         status->virtualization_mode));
     for (uint32_t i = 0; i < status->num_gpu_partition; i++) {
         if (status->gpu_partition[i].valid()) {
             proto_status->add_gpupartition(status->gpu_partition[i].id,


### PR DESCRIPTION
## Motivation
Add gpu virtualization mode immuatable attribute (#103674)

## Technical details
This helps identify the deployment environment for GPU.
1. Baremetal case where amdgpu driver is used
2. Host case where gim driver is used
3. Guest case where amdgpu driver used on VF

## Test
```bash
[root@gpu-operator-metrics-exporter-26pc4 ~]# gpuctl show gpu all | grep -i Virtu
  Virtualization mode                    : guest
  Virtualization mode                    : guest
  Virtualization mode                    : guest
  Virtualization mode                    : guest
  Virtualization mode                    : guest
  Virtualization mode                    : guest
  Virtualization mode                    : guest
  Virtualization mode                    : guest

[root@default-metrics-exporter-wws62 ~]# gpuctl show gpu all | grep Virtu
  Virtualization Mode                    : host
[root@default-metrics-exporter-wws62 ~]#
```


