### PR TITLE
Create mock CPER records for mock gpuagent

### DIFF
--- a/sw/nic/gpuagent/api/smi/smi_api_mock.cc
+++ b/sw/nic/gpuagent/api/smi/smi_api_mock.cc
@@ -21,6 +21,9 @@ limitations under the License.
 //----------------------------------------------------------------------------
 
 #include <random>
+#include <sstream>
+#include <iomanip>
+#include <iostream>
 #include "nic/sdk/include/sdk/base.hpp"
 #include "nic/sdk/lib/event_thread/event_thread.hpp"
 #include "nic/gpuagent/core/aga_core.hpp"
@@ -679,14 +682,20 @@ sdk_ret_t
 smi_gpu_get_cper_entries (aga_gpu_handle_t gpu_handle,
                           aga_cper_severity_t severity, aga_cper_info_t *info)
 {
-    info = {};
+    uint64_t gpu_key;
+    std::ostringstream oss;
     auto cper_entry = &info->cper_entry[info->num_cper_entry++];
 
-    cper_entry->record_id = "7:1";
+    gpu_key = (uint64_t)gpu_handle;
+    oss << (gpu_key % 8) + 1 << ":" << (gpu_key+ 5) % 8 + 1;
+    cper_entry->record_id = oss.str();
     cper_entry->severity = AGA_CPER_SEVERITY_FATAL;
     cper_entry->revision = 256;
 
-    cper_entry->timestamp = "2025-09-12 15:00:27";
+    oss.str("");
+    oss << std::setfill('0') << "2025-09-" << std::setw(2) <<
+        (gpu_key % 31) + 1 << " 15:00:" << std::setw(2) << (gpu_key % 60) + 1;
+    cper_entry->timestamp = oss.str();
     cper_entry->notification_type = AGA_CPER_NOTIFICATION_TYPE_MCE;
     cper_entry->creator_id = "amdgpu";
     cper_entry->num_af_id = 1;


### PR DESCRIPTION
```
[root@3800085e379b nic]#gpuctl show gpu cper-records
------------------------------------------------------------------------------------------------------------------------------------------------------------                                                                               
Timestamp           GPU                                     RecordId        Severity                 Revision  CreatorId NtfnType       AMDFieldId                                                                                         
------------------------------------------------------------------------------------------------------------------------------------------------------------                                                                               
2025-09-28 15:00:12 4369c0a8-420f-4242-0f51-d89b47c87169    8:5             FATAL                    256       amdgpu    MCE            30                                                                                                 
2025-09-06 15:00:16 4369c0a8-420e-4242-d337-ff3d9004bac2    4:1             FATAL                    256       amdgpu    MCE            30                                                                                                 
2025-09-22 15:00:36 4369c0a8-420d-4242-6fc0-a9e46b868f3d    8:5             FATAL                    256       amdgpu    MCE            30                                                                                                 
2025-09-09 15:00:49 4369c0a8-4202-4242-dcd9-cc9752d895f9    5:2             FATAL                    256       amdgpu    MCE            30                                                                                                 
2025-09-22 15:00:06 4369c0a8-4201-4242-3d05-21da1ce7a8b0    6:3             FATAL                    256       amdgpu    MCE            30                                                                                                 
2025-09-20 15:00:33 4369c0a8-4200-4242-302a-4f515d65d082    1:6             FATAL                    256       amdgpu    MCE            30                                                                                                 
2025-09-02 15:00:40 4369c0a8-4204-4242-5316-646cf35b7d5c    4:1             FATAL                    256       amdgpu    MCE            30                                                                                                 
2025-09-29 15:00:33 4369c0a8-420a-4242-e4bf-3a801f4d084c    5:2             FATAL                    256       amdgpu    MCE            30                                                                                                 
2025-09-26 15:00:09 4369c0a8-4203-4242-4478-7ab0a2cfcc68    5:2             FATAL                    256       amdgpu    MCE            30                                                                                                 
2025-09-05 15:00:35 4369c0a8-4205-4242-f6bb-7101fe3ca666    7:4             FATAL                    256       amdgpu    MCE            30                                                                                                 
2025-09-13 15:00:05 4369c0a8-4209-4242-445d-7a07b6ec5731    5:2             FATAL                    256       amdgpu    MCE            30                                                                                                 
2025-09-13 15:00:27 4369c0a8-4206-4242-4ecc-fba424a1c42e    7:4             FATAL                    256       amdgpu    MCE            30                                                                                                 
2025-09-03 15:00:24 4369c0a8-4207-4242-8731-a8b648e0e577    8:5             FATAL                    256       amdgpu    MCE            30                                                                                                 
2025-09-17 15:00:12 4369c0a8-4208-4242-5738-ae315d849bf0    8:5             FATAL                    256       amdgpu    MCE            30                                                                                                 
2025-09-05 15:00:28 4369c0a8-420b-4242-6b88-687cc1aea7fc    4:1             FATAL                    256       amdgpu    MCE            30                                                                                                 
2025-09-05 15:00:45 4369c0a8-420c-4242-d086-df38dd07da75    1:6             FATAL                    256       amdgpu    MCE            30                                                                                                 