### PR TITLE
Add unix domain socket for grpc communication

### DIFF
--- a/sw/nic/gpuagent/cli/cmd/root.go
+++ b/sw/nic/gpuagent/cli/cmd/root.go
@@ -32,8 +32,9 @@ import (
 )
 
 var (
-	svcURL  string
-	svcPort string
+	svcURL        string
+	svcPort       string
+	svcSocketPath string
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -59,6 +60,9 @@ func init() {
 	RootCmd.PersistentFlags().StringVar(&svcPort, "node-svc-port",
 		utils.GRPCDefaultPort,
 		"Remote node's service port")
+	RootCmd.PersistentFlags().StringVar(&svcSocketPath, "node-svc-socket",
+		utils.GRPCDefaultSocketPath,
+		"Unix socket path for GPU agent connection")
 }
 
 // NewGpuctlCommand exports the RootCmd for bash-completion
@@ -67,7 +71,21 @@ func NewGpuctlCommand() *cobra.Command {
 }
 
 func initConfig() {
-	// Note: initialize any config variables if required
-	utils.GRPCDefaultBaseURL = svcURL
-	utils.GRPCDefaultPort = svcPort
+	// NOTE:
+	// 1. initialize any config variables if required
+	// 2. priority: --node-svc-socket > TCP/IP
+
+	// check if user explicitly provided a socket path (different from default)
+	if svcSocketPath != utils.GRPCDefaultSocketPath {
+		// explicit socket path specified by user
+		utils.GRPCDefaultSocketPath = svcSocketPath
+	}
+
+	// check if default socket file exists
+	if _, err := os.Stat(utils.GRPCDefaultSocketPath); err != nil {
+		// socket file doesn't exist, use TCP/IP connection
+		utils.GRPCDefaultSocketPath = ""
+		utils.GRPCDefaultBaseURL = svcURL
+		utils.GRPCDefaultPort = svcPort
+	}
 }

--- a/sw/nic/gpuagent/cli/utils/client.go
+++ b/sw/nic/gpuagent/cli/utils/client.go
@@ -30,8 +30,9 @@ import (
 )
 
 var (
-	GRPCDefaultBaseURL = "127.0.0.1"
-	GRPCDefaultPort    = "50061"
+	GRPCDefaultBaseURL    = "127.0.0.1"
+	GRPCDefaultPort       = "50061"
+	GRPCDefaultSocketPath = "/var/run/gpuagent.sock"
 )
 
 const (
@@ -66,16 +67,24 @@ func getClientReqTimeout() (uint, error) {
 	return uint(timeout), nil
 }
 
-// createNewGRPCClient creates a grpc connection to HAL
-// we first check if secure grpc exists and if not fallback
-// to regular grpc
+// createNewGRPCClient creates a grpc connection to GPU agent
+// supports both TCP/IP and Unix socket connections
 func createNewGRPCClient() (*grpc.ClientConn, error) {
-	// unsecure grpc
-	agaPort := os.Getenv("AGA_GRPC_PORT")
-	if agaPort == "" {
-		agaPort = GRPCDefaultPort
+	var srvURL string
+
+	// check if Unix socket path is specified
+	if GRPCDefaultSocketPath != "" {
+		// use Unix socket
+		srvURL = "unix:" + GRPCDefaultSocketPath
+	} else {
+		// use TCP/IP
+		agaPort := os.Getenv("AGA_GRPC_PORT")
+		if agaPort == "" {
+			agaPort = GRPCDefaultPort
+		}
+		srvURL = GRPCDefaultBaseURL + ":" + agaPort
 	}
-	srvURL := GRPCDefaultBaseURL + ":" + agaPort
+
 	timeout, err := getClientPortConnTimeout()
 	if err != nil {
 		return nil, err

--- a/sw/nic/gpuagent/init.cc
+++ b/sw/nic/gpuagent/init.cc
@@ -24,6 +24,12 @@ limitations under the License.
 //----------------------------------------------------------------------------
 
 #include <memory>
+#include <cerrno>
+#include <cstring>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
 #include <grpc++/grpc++.h>
 #include "nic/sdk/include/sdk/base.hpp"
 #include "nic/sdk/lib/logger/logger.h"
@@ -184,7 +190,7 @@ create_gpus (void)
 }
 
 /// \brief    start the gRPC server
-/// \param[in] grpc_server    gRPC server (IP:port) string
+/// \param[in] grpc_server    gRPC server (IP:port or unix:socket_path) string
 static void
 grpc_server_start (const std::string& grpc_server)
 {
@@ -192,6 +198,7 @@ grpc_server_start (const std::string& grpc_server)
     TopoSvcImpl topo_svc;
     DebugSvcImpl debug_svc;
     EventSvcImpl event_svc;
+    std::string socket_path;
     ServerBuilder server_builder;
     DebugGPUSvcImpl debug_gpu_svc;
     GPUWatchSvcImpl gpu_watch_svc;
@@ -231,6 +238,24 @@ grpc_server_start (const std::string& grpc_server)
     AGA_TRACE_DEBUG("gRPC server listening on {} ...",
                     grpc_server.c_str());
     g_grpc_server = server_builder.BuildAndStart();
+    if (g_grpc_server == nullptr) {
+        AGA_TRACE_ERR("Failed to start gRPC server on {}, err - {}",
+                      grpc_server.c_str(), strerror(errno));
+        exit(1);
+    }
+    // determine gRPC server type
+    if (grpc_server.compare(0, 5, "unix:") == 0) {
+        // extract socket path from "unix:path" format
+        socket_path = grpc_server.substr(5); // skip "unix:"
+    }
+    if (!socket_path.empty()) {
+        // set root only permission for socket in case of UDS transport for gRPC
+        if (chmod(socket_path.c_str(), 0600) != 0) {
+            AGA_TRACE_ERR("Failed to set permissions on socket {}, err - {}",
+                          socket_path.c_str(), strerror(errno));
+            exit(1);
+        }
+    }
     g_grpc_server->Wait();
 }
 

--- a/sw/nic/gpuagent/init.hpp
+++ b/sw/nic/gpuagent/init.hpp
@@ -36,10 +36,12 @@ limitations under the License.
 #define AGA_DEFAULT_GRPC_SERVER_PORT          50061
 /// gRPC server:port string length
 #define AGA_GRPC_SERVER_STR_LEN               64
+/// Default Unix socket path
+#define AGA_DEFAULT_UNIX_SOCKET_PATH          "/var/run/gpuagent.sock"
 
 /// \brief initialization parameters
 typedef struct aga_init_params_s {
-    // gRPC server (IP:port)
+    // gRPC server (IP:port or unix socket path)
     char grpc_server[AGA_GRPC_SERVER_STR_LEN];
 } aga_init_params_t;
 

--- a/sw/nic/gpuagent/main.cc
+++ b/sw/nic/gpuagent/main.cc
@@ -31,6 +31,13 @@ limitations under the License.
 #include <thread>
 #include <iostream>
 #include <fstream>
+#include <signal.h>
+#include <cerrno>
+#include <cstring>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
 #include <grpc++/grpc++.h>
 #include <arpa/inet.h>
 #include "nic/sdk/include/sdk/base.hpp"
@@ -47,14 +54,125 @@ using grpc::ServerBuilder;
 using grpc::ServerContext;
 using grpc::Status;
 
+// global variable to store socket path for cleanup
+static std::string g_socket_path;
+
 /// \brief    print usage information
 static void inline
 print_usage (char **argv)
 {
     fprintf(stdout, "Usage : %s [-p <port> | --grpc-server-port <port>] "
-            "[-i <ip-addr> | --grpc-server-ip <ip-addr>]\n\n",
+            "[-i <ip-addr> | --grpc-server-ip <ip-addr>] "
+            "[-s <socket-path> | --grpc-unix-socket <socket-path>]\n\n",
             argv[0]);
+    fprintf(stdout, "Options:\n");
+    fprintf(stdout, "  -p, --grpc-server-port <port>       gRPC server port (default: %u)\n",
+            AGA_DEFAULT_GRPC_SERVER_PORT);
+    fprintf(stdout, "  -i, --grpc-server-ip <ip-addr>      gRPC server IP address (default: 127.0.0.1)\n");
+    fprintf(stdout, "  -s, --grpc-unix-socket <path>       Use Unix socket instead of TCP/IP (default: %s)\n",
+            AGA_DEFAULT_UNIX_SOCKET_PATH);
     fprintf(stdout, "Use -h | --help for help\n");
+}
+
+/// \brief    cleanup Unix socket file on exit
+/// \param[in] socket_path
+static void
+clean_unix_socket (const std::string& socket_path)
+{
+    if (unlink(socket_path.c_str()) != 0) {
+        fprintf(stderr, "Failed to remove socket file %s on exit, err - %s\n",
+                socket_path.c_str(), strerror(errno));
+    }
+}
+
+/// \brief    signal handler for cleanup
+static void
+signal_handler (int signum)
+{
+    if (!g_socket_path.empty()) {
+        clean_unix_socket(g_socket_path);
+    }
+    exit(0);
+}
+
+/// \brief    prepare Unix socket for gRPC server
+/// \param[in] socket_path    Unix socket file path
+/// \return   SDK_RET_OK on success, SDK_RET_ERR on failure
+static sdk_ret_t
+prepare_unix_socket (const std::string& socket_path)
+{
+    int test_sock;
+    struct stat st;
+    size_t last_slash;
+    struct stat dir_st;
+    socklen_t addr_len;
+    std::string dir_path;
+    struct sockaddr_un addr;
+
+    // validate socket path length
+    if (socket_path.length() >= sizeof(addr.sun_path)) {
+        fprintf(stderr, "Error: Socket path too long (max %zu chars): %s\n",
+                sizeof(addr.sun_path) - 1, socket_path.c_str());
+        return SDK_RET_ERR;
+    }
+
+    // check if socket file exists
+    if (stat(socket_path.c_str(), &st) == 0) {
+        // socket file exists - check if it's in use
+        if (S_ISSOCK(st.st_mode)) {
+            // try to connect to see if another instance is running
+            test_sock = socket(AF_UNIX, SOCK_STREAM, 0);
+            if (test_sock >= 0) {
+                memset(&addr, 0, sizeof(addr));
+                addr.sun_family = AF_UNIX;
+                strncpy(addr.sun_path, socket_path.c_str(),
+                        sizeof(addr.sun_path) - 1);
+                addr_len = offsetof(struct sockaddr_un, sun_path) +
+                           strlen(addr.sun_path) + 1;
+
+                if (connect(test_sock, (struct sockaddr*)&addr, addr_len) == 0) {
+                    // another instance is running
+                    close(test_sock);
+                    fprintf(stderr, "Error: Another GPU agent instance is "
+                            "already running on socket %s\n",
+                            socket_path.c_str());
+                    return SDK_RET_ERR;
+                }
+                close(test_sock);
+            }
+
+            // socket exists but not in use - clean it up
+            if (unlink(socket_path.c_str()) != 0) {
+                fprintf(stderr, "Error: Failed to remove stale socket file %s, "
+                        "err - %s\n", socket_path.c_str(), strerror(errno));
+                return SDK_RET_ERR;
+            }
+        } else {
+            // file exists but is not a socket
+            fprintf(stderr, "Error: Path %s exists but is not a socket\n",
+                    socket_path.c_str());
+            return SDK_RET_ERR;
+        }
+    }
+
+    // ensure parent directory exists
+    last_slash = socket_path.find_last_of('/');
+    if (last_slash != std::string::npos) {
+        dir_path = socket_path.substr(0, last_slash);
+        if (stat(dir_path.c_str(), &dir_st) != 0) {
+            // directory doesn't exist - create it
+            if (mkdir(dir_path.c_str(), 0755) != 0 && errno != EEXIST) {
+                fprintf(stderr, "Error: Failed to create directory %s, err - %s\n",
+                        dir_path.c_str(), strerror(errno));
+                return SDK_RET_ERR;
+            }
+        } else if (!S_ISDIR(dir_st.st_mode)) {
+            fprintf(stderr, "Error: Path %s exists but is not a directory\n",
+                    dir_path.c_str());
+            return SDK_RET_ERR;
+        }
+    }
+    return SDK_RET_OK;
 }
 
 int
@@ -66,17 +184,20 @@ main (int argc, char **argv)
     std::string grpc_server;
     std::string grpc_server_ip;
     std::string grpc_server_port;
+    std::string grpc_unix_socket;
+    bool use_unix_socket = false;
     aga_init_params_t init_params = {};
     // command line options
     struct option longopts[] = {
         { "grpc-server-port", required_argument, NULL, 'p' },
         { "grpc-server-ip",   required_argument, NULL, 'i' },
+        { "grpc-unix-socket", optional_argument, NULL, 's' },
         { "help",             no_argument,       NULL, 'h' },
         { 0,                  0,                 NULL,  0  }
     };
 
     // parse CLI options
-    while ((oc = getopt_long(argc, argv, ":hp:i:", longopts, NULL)) != -1) {
+    while ((oc = getopt_long(argc, argv, ":hp:i:s:", longopts, NULL)) != -1) {
         switch (oc) {
         case 'p':
             try {
@@ -107,6 +228,15 @@ main (int argc, char **argv)
             grpc_server_ip = optarg;
             break;
 
+        case 's':
+            if (optarg) {
+                grpc_unix_socket = optarg;
+            } else {
+                grpc_unix_socket = AGA_DEFAULT_UNIX_SOCKET_PATH;
+            }
+            use_unix_socket = true;
+            break;
+
         case 'h':
             print_usage(argv);
             exit(0);
@@ -117,23 +247,49 @@ main (int argc, char **argv)
             break;
         }
     }
-    // use default IP for gRPC server if not specified
-    if (grpc_server_ip.empty()) {
-        grpc_server_ip = "127.0.0.1";
+    // determine gRPC server type and address
+    if (use_unix_socket) {
+        // use Unix socket
+        grpc_server = "unix:" + grpc_unix_socket;
+    } else {
+        // use TCP/IP
+        // use default IP for gRPC server if not specified
+        if (grpc_server_ip.empty()) {
+            grpc_server_ip = "127.0.0.1";
+        }
+        // use default port for gRPC server if not specified
+        if (grpc_server_port.empty()) {
+            grpc_server_port = std::to_string(AGA_DEFAULT_GRPC_SERVER_PORT);
+        }
+        grpc_server = grpc_server_ip + ":" + grpc_server_port;
     }
-    // use default port for gRPC server if not specified
-    if (grpc_server_port.empty()) {
-        grpc_server_port = std::to_string(AGA_DEFAULT_GRPC_SERVER_PORT);
-    }
-    grpc_server = grpc_server_ip + ":" + grpc_server_port;
     // initialize the init params
     strncpy(init_params.grpc_server, grpc_server.c_str(),
             AGA_GRPC_SERVER_STR_LEN);
     init_params.grpc_server[AGA_GRPC_SERVER_STR_LEN - 1] = '\0';
-
+    // handle Unix socket setup before initialization
+    if (use_unix_socket) {
+        // prepare Unix socket (check for existing instances, cleanup, etc.)
+        ret = prepare_unix_socket(grpc_unix_socket);
+        if (ret != SDK_RET_OK) {
+            exit(1);
+        }
+        // save socket path for cleanup
+        g_socket_path = grpc_unix_socket;
+        // register signal handlers for cleanup
+        signal(SIGINT, signal_handler);
+        signal(SIGTERM, signal_handler);
+    } else {
+        // cleanup any existing Unix socket on TCP initialization
+        clean_unix_socket(AGA_DEFAULT_UNIX_SOCKET_PATH);
+    }
     // initialize the agent
     ret = aga_init(&init_params);
     SDK_ASSERT(ret == SDK_RET_OK);
     fprintf(stderr, "gRPC server exited, agent shutting down ...\n");
+    // cleanup Unix socket on exit
+    if (use_unix_socket && !g_socket_path.empty()) {
+        clean_unix_socket(g_socket_path);
+    }
     return 0;
 }


### PR DESCRIPTION
## Motivation

Add support to run grpc over unix domain socket for secure access

## Technical Details

- reduce dependency of web services over tcp ip communication
- to enable socket based grpc new argument with the socket path to use is introduced `-s, --grpc-unix-socket <path>`
- gpuctl updated to check for default socket file present to automatically detect socket for gracefully switching to socket based access or revert to tcp based, arg `node-svc-socket` added to set non default custom socket for grpc connection

## Test Plan
```bash
root@33e2dab2b163:/# ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   4364  3188 pts/0    Ss   20:37   0:00 /bin/bash -e /home/amd/tools/entrypoint.sh
root           8  0.0  0.0   4628  3812 pts/0    S+   20:37   0:00 bash
root          48  0.4  0.0 942488 31092 ?        Sl   20:46   0:00 /home/amd/bin/gpuagent -s /var/run/gpuagent.sock
root          72  0.0  0.0   4628  3932 pts/2    Ss   20:46   0:00 bash
root          91  0.0  0.0   7064  1548 pts/2    R+   20:47   0:00 ps aux
root@33e2dab2b163:/# gpuctl show gpu all | grep gpus
No. of gpus : 1
root@33e2dab2b163:/# gpuctl --node-svc-socket /var/run/gpuagent.sock show gpu all | grep -i vendor
  Card vendor                            : AMD
  Memory vendor                          : samsung
    VRAM vendor                          : samsung
root@33e2dab2b163:/
```

