### PR TITLE
per process gpu compute unit occupancy percent value

### DIFF
--- a/sw/nic/gpuagent/api/include/aga_gpu.hpp
+++ b/sw/nic/gpuagent/api/include/aga_gpu.hpp
@@ -31,6 +31,7 @@ limitations under the License.
 #define AGA_GPU_MAX_HBM                        4
 #define AGA_GPU_MAX_FIRMWARE_VERSION           85
 #define AGA_GPU_MAX_KFD_PID                    8
+#define AGA_GPU_MAX_PROCESS_PER_DEVICE         32
 #define AGA_GPU_MAX_VOLTAGE_CURVE_POINT        4
 #define AGA_GPU_MIN_OVERDRIVE_LEVEL            0
 #define AGA_GPU_MAX_OVERDRIVE_LEVEL            20
@@ -276,6 +277,14 @@ typedef struct aga_gpu_clock_status_s {
     bool deep_sleep;
 } aga_gpu_clock_status_t;
 
+/// \brief GPU process info
+typedef struct aga_gpu_process_info_s {
+    /// process id
+    uint32_t pid;
+    /// compute unit usage in percent
+    uint32_t cu_occupancy;
+} aga_gpu_process_info_t;
+
 /// \brief GPU voltage curve point
 typedef struct aga_gpu_voltage_curve_point_s {
     /// curve point
@@ -464,7 +473,7 @@ typedef struct aga_gpu_status_s {
     /// number of Kenral Fusion Driver process ids using the GPU
     uint32_t num_kfd_process_id;
     /// Kernel Fusion Driver (KFD) process ids using the GPU
-    uint32_t kfd_process_id[AGA_GPU_MAX_KFD_PID];
+    uint32_t kfd_process_id[AGA_GPU_MAX_PROCESS_PER_DEVICE];
     /// GPU RAS status
     aga_gpu_ras_status_t ras_status;
     /// xgmi status
@@ -500,6 +509,8 @@ typedef struct aga_gpu_status_s {
     uint32_t drm_card_id;
     // GPU virtualization mode
     aga_gpu_virtualization_mode_t virtualization_mode;
+    // GPU process status
+    aga_gpu_process_info_t process_info[AGA_GPU_MAX_PROCESS_PER_DEVICE];
 } aga_gpu_status_t;
 
 /// \brief GPU PCIe statistics

--- a/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
+++ b/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
@@ -452,64 +452,43 @@ static sdk_ret_t
 smi_fill_gpu_kfd_pid_status_ (aga_gpu_handle_t gpu_handle,
                               uint32_t gpu_id, aga_gpu_status_t *status)
 {
+    amdsmi_proc_info_t *list;
     amdsmi_status_t amdsmi_ret;
-    uint32_t gpu_list[AGA_MAX_GPU];
-    amdsmi_process_info_t *pid_info;
-    uint32_t value_32, num_pid = 0, num_gpus = AGA_MAX_GPU;
+    uint32_t max_processes = 0;
 
-    // kernel fusion driver pids
-    amdsmi_ret = amdsmi_get_gpu_compute_process_info(NULL, &value_32);
+    amdsmi_ret = amdsmi_get_gpu_process_list(gpu_handle, &max_processes, NULL);
     if (unlikely(amdsmi_ret != AMDSMI_STATUS_SUCCESS)) {
-        AGA_TRACE_ERR("Failed to get KFD pid count, err {}", amdsmi_ret);
+        AGA_TRACE_ERR("Failed to get number of processes running on GPU {}, err {}",
+                      gpu_handle, amdsmi_ret);
+        return amdsmi_ret_to_sdk_ret(amdsmi_ret);
+    }
+    list = (amdsmi_proc_info_t *)malloc(sizeof(amdsmi_proc_info_t) * max_processes);
+    if (!list) {
+        AGA_TRACE_ERR("Failed to allocate memory for process list for GPU {}",
+                      gpu_handle);
+        return SDK_RET_OOM;
+    }
+    amdsmi_ret = amdsmi_get_gpu_process_list(gpu_handle, &max_processes, list);
+    if (unlikely(amdsmi_ret != AMDSMI_STATUS_SUCCESS)) {
+        AGA_TRACE_ERR("Failed to get process list for GPU {}, err {}",
+                      gpu_handle, amdsmi_ret);
+        free(list);
         return amdsmi_ret_to_sdk_ret(amdsmi_ret);
     } else {
-        // if pid count is non zero, get the pid info
-        if (value_32) {
-            pid_info =
-                (amdsmi_process_info_t *)malloc(sizeof(amdsmi_process_info_t) *
-                                                value_32);
-            if (pid_info == NULL) {
-                AGA_TRACE_ERR("Failed to allocate KFD pid buffer, GPU {}");
-                return SDK_RET_OOM;
+        status->num_kfd_process_id = max_processes;
+        for (uint32_t i = 0; i < max_processes; i++) {
+            if (i == AGA_GPU_MAX_PROCESS_PER_DEVICE) {
+                AGA_TRACE_ERR("Number of processes using GPU {} exceeds max "
+                              "supported value of {}, some processes will not "
+                              "be reported", gpu_handle, AGA_GPU_MAX_PROCESS_PER_DEVICE);
+                status->num_kfd_process_id = AGA_GPU_MAX_PROCESS_PER_DEVICE;
+                break;
             }
-            amdsmi_ret = amdsmi_get_gpu_compute_process_info(pid_info,
-                                                             &value_32);
-            if (unlikely(amdsmi_ret != AMDSMI_STATUS_SUCCESS)) {
-                free(pid_info);
-                AGA_TRACE_ERR("Failed to get KFD pid info, err {}", amdsmi_ret);
-                return amdsmi_ret_to_sdk_ret(amdsmi_ret);
-            }
-            // loop thru pids, get the list of GPUs using each pid and
-            // update per GPU kfd process list
-            for (uint32_t i = 0; i < value_32; i++) {
-                num_gpus = AGA_MAX_GPU;
-                amdsmi_ret =
-                    amdsmi_get_gpu_compute_process_gpus(pid_info[i].process_id,
-                                                        gpu_list, &num_gpus);
-                if (unlikely(amdsmi_ret != AMDSMI_STATUS_SUCCESS)) {
-                    AGA_TRACE_ERR("Failed to get GPU list of pid {}, err {}",
-                                  pid_info[i].process_id, amdsmi_ret);
-                    continue;
-                }
-                for (uint32_t j = 0; j < num_gpus; j++) {
-                    if (gpu_list[j] == gpu_id) {
-                        if (num_pid == (AGA_GPU_MAX_KFD_PID - 1)) {
-                            AGA_TRACE_DEBUG("Reached max KFD processes {} "
-                                            "using the GPU {}, pid {} is "
-                                            "ignored", AGA_GPU_MAX_KFD_PID,
-                                            gpu_handle, pid_info[i].process_id);
-                            break;
-                        }
-                        status->kfd_process_id[num_pid++] =
-                            pid_info[i].process_id;
-                        break;
-                    }
-                }
-            }
-            status->num_kfd_process_id = num_pid;
-            // free pid_info memory
-            free(pid_info);
+            status->process_info[i].pid = (uint32_t)list[i].pid;
+            status->process_info[i].cu_occupancy = list[i].cu_occupancy;
+            status->kfd_process_id[i] = (uint32_t)list[i].pid;
         }
+        free(list);
     }
     return SDK_RET_OK;
 }

--- a/sw/nic/gpuagent/cli/cmd/gpu.go
+++ b/sw/nic/gpuagent/cli/cmd/gpu.go
@@ -909,12 +909,13 @@ func printGPUStatus(gpu *aga.GPU, statusOnly bool) {
 		}
 		idxr++
 	}
-	kfdPids := status.GetKFDProcessId()
-	if len(kfdPids) != 0 {
-		kfdPidStr := fmt.Sprintf("%-38s : ", "KFD process id using GPU")
-		for i := 0; i < len(kfdPids); i++ {
-			fmt.Printf(indent+"%-41s%d\n", kfdPidStr, kfdPids[i])
-			kfdPidStr = ""
+	processStatus := status.GetProcessStatus()
+	if processStatus != nil && len(processStatus.GetProcessInfo()) != 0 {
+		processInfo := processStatus.GetProcessInfo()
+		for _, pInfo := range processInfo {
+			fmt.Printf(indent+"%-38s : %d %%\n",
+				fmt.Sprintf("Process id %d CU occupancy", pInfo.GetPId()),
+				pInfo.GetCUOccupancy())
 		}
 	}
 	// TODO: fill GPU RAS status

--- a/sw/nic/gpuagent/protos/gpu.proto
+++ b/sw/nic/gpuagent/protos/gpu.proto
@@ -434,7 +434,8 @@ message GPUStatus {
   uint32                      DRMCardId          = 28;
   // GPU virtualization mode
   GPUVirtualizationMode       VirtualizationMode = 29;
-
+  // GPU process information
+  GPUProcessStatus            ProcessStatus      = 30;
 }
 
 // GPU temperature information
@@ -583,6 +584,16 @@ message GPUViolationStats {
   repeated uint64 GFXBelowHostLimitTotalPercentage  = 19;
 }
 
+message ProcessInfo {
+  // process id
+  uint32 PId         = 1;
+  // compute unit usage in percent
+  uint32 CUOccupancy = 2;
+}
+
+message GPUProcessStatus {
+  repeated ProcessInfo ProcessInfo = 1;
+}
 
 // GPU statistics
 message GPUStats {

--- a/sw/nic/gpuagent/svc/gpu_to_proto.hpp
+++ b/sw/nic/gpuagent/svc/gpu_to_proto.hpp
@@ -212,6 +212,17 @@ aga_gpu_fw_version_to_proto (GPUStatus *proto_status,
 }
 
 static inline void
+aga_gpu_process_status_to_proto (amdgpu::GPUProcessStatus *proto_status,
+                                 const aga_gpu_status_t *status)
+{
+    for (uint32_t i = 0; i < status->num_kfd_process_id; i++) {
+        auto process_info = proto_status->add_processinfo();
+        process_info->set_pid(status->process_info[i].pid);
+        process_info->set_cuoccupancy(status->process_info[i].cu_occupancy);
+    }
+}
+
+static inline void
 aga_gpu_clock_status_to_proto (GPUStatus *proto_status,
                                const aga_gpu_status_t *status)
 {
@@ -399,7 +410,9 @@ aga_gpu_api_status_to_proto (GPUStatus *proto_status,
             // copy only non-zero process ids only
             proto_status->add_kfdprocessid(status->kfd_process_id[i]);
         }
-    }
+    }    
+    aga_gpu_process_status_to_proto(proto_status->mutable_processstatus(),
+                                    status);
     // TODO: fill RAS status
     aga_gpu_xgmi_status_to_proto(proto_status->mutable_xgmistatus(),
                                  &status->xgmi_status);


### PR DESCRIPTION
```bash

[root@exporter-amdgpu-metrics-exporter-lgdpz ~]# gpuctl show gpu all
 -- snipped --
    GPU clock type                         : FABRIC_0
    Frequency (in MHz)                   : 1300
    Frequency range (in MHz)             : 1300 - 1800
  Process id 2304296 CU occupancy        : 0 %
  Process id 2306056 CU occupancy        : 0 %
  Process id 2306123 CU occupancy        : 0 %
  Process id 2306124 CU occupancy        : 0 %
  Process id 2306125 CU occupancy        : 0 %
  Process id 2306126 CU occupancy        : 0 %
  Process id 2306127 CU occupancy        : 0 %
  Process id 2306128 CU occupancy        : 5 %
  Process id 2306129 CU occupancy        : 0 %
  Process id 2306130 CU occupancy        : 0 %

 -- snip
```