### PR TITLE
issue : some non partition metrics were not visible

### DIFF
--- a/sw/nic/gpuagent/init.cc
+++ b/sw/nic/gpuagent/init.cc
@@ -158,7 +158,7 @@ create_gpus (void)
         entry->set_handle(gpu[i].handle);
         // num_parition is no more working in new library; derive it from
         // compute partition type
-        if (gpu[i].compute_partition = AGA_GPU_COMPUTE_PARTITION_TYPE_SPX) {
+        if (gpu[i].compute_partition != AGA_GPU_COMPUTE_PARTITION_TYPE_SPX) {
             // set partition state
             entry->set_is_partitioned();
         }


### PR DESCRIPTION
root cause : fix partition detection condition was wrong
fix : fixed to detect correctly

```bash
[root@exporter-amdgpu-metrics-exporter-kv686 ~]# gpuctl show gpu all | grep -i gfx
  GFX activity                         : 100
  GFX utilization                      : 100% 100% 100% 100% 100% 100% 100% 100%
GFX activity accumulated               : 2511653893
[root@exporter-amdgpu-metrics-exporter-kv686 ~]#

```