### PR TITLE
GPUAgent - Add GPUAGENT_EVENTS_DISABLE env variable to disable event monitoring

### DIFF
--- a/sw/nic/gpuagent/api/aga_state.cc
+++ b/sw/nic/gpuagent/api/aga_state.cc
@@ -33,6 +33,8 @@ namespace aga {
 
 /// singleto instance of all agent state
 aga_state g_aga_state;
+/// global flag to indicate if events are disabled
+bool g_events_disabled = false;
 
 aga_state::aga_state() {
     memset(state_, 0, sizeof(state_));
@@ -49,6 +51,15 @@ aga_state::store_init_(void) {
 
 sdk_ret_t
 aga_state::init(void) {
+    const char *env_val;
+
+    // check if events are disabled via environment variable
+    env_val = std::getenv("GPUAGENT_EVENTS_DISABLE");
+    if (env_val && strcmp(env_val, "1") == 0) {
+        g_events_disabled = true;
+        AGA_TRACE_INFO("Event monitoring disabled via GPUAGENT_EVENTS_DISABLE "
+                       "environment variable");
+    }
     // initialize all the internal databases
     store_init_();
     return SDK_RET_OK;

--- a/sw/nic/gpuagent/api/aga_state.hpp
+++ b/sw/nic/gpuagent/api/aga_state.hpp
@@ -118,6 +118,8 @@ private:
 };
 /// \brief    global (singleton) GPU state instance
 extern aga_state g_aga_state;
+/// \brief    global flag to indicate if events are disabled
+extern bool g_events_disabled;
 /// \@}
 
 }    // namespace aga
@@ -138,6 +140,14 @@ static inline gpu_watch_state *
 gpu_watch_db (void)
 {
     return aga::g_aga_state.gpu_watch_db();
+}
+
+/// \brief    check if events are disabled
+/// \return   true if events are disabled, false otherwise
+static inline bool
+events_disabled (void)
+{
+    return aga::g_events_disabled;
 }
 
 #endif    // __AGA_STATE_HPP__

--- a/sw/nic/gpuagent/api/smi/amdsmi/smi_state.cc
+++ b/sw/nic/gpuagent/api/smi/amdsmi/smi_state.cc
@@ -1131,6 +1131,9 @@ smi_state::event_monitor_init(void) {
     amdsmi_status_t status;
     gpu_event_record_t null_event_record = {};
 
+    if (events_disabled()) {
+        return SDK_RET_OK;
+    }
     // initialize the s/w state
     for (uint32_t d = 0; d < num_gpu_; d++) {
         SDK_SPINLOCK_INIT(&gpu_event_db_[gpu_handles_[d]].slock,
@@ -1158,6 +1161,9 @@ smi_state::event_monitor_init(void) {
 
 sdk_ret_t
 smi_state::event_monitor_cleanup(void) {
+    if (events_disabled()) {
+        return SDK_RET_OK;
+    }
     // stop monitoring
     for (uint32_t d = 0; d < num_gpu_; d++) {
         amdsmi_stop_gpu_event_notification(gpu_handles_[d]);
@@ -1286,6 +1292,9 @@ sdk_ret_t
 smi_state::event_read(aga_event_read_cb_t cb, void *ctxt) {
     aga_event_t event;
 
+    if (events_disabled()) {
+        return SDK_RET_OK;
+    }
     // traverse the event database per device
     for (uint32_t d = 0; d < num_gpu_; d++) {
         auto gpu = gpu_db()->find(gpu_handles_[d]);
@@ -1321,6 +1330,9 @@ event_monitor_timer_cb_ (event::timer_t *timer)
     uint32_t num_elem = AGA_MAX_GPU * AGA_EVENT_ID_MAX;
     amdsmi_evt_notification_data_t event_ntfn_data[num_elem];
 
+    if (events_disabled()) {
+        return;
+    }
     // get event information
     status = amdsmi_get_gpu_event_notification(AGA_SMI_EVENT_MONITOR_INTERVAL,
                                                &num_elem, event_ntfn_data);
@@ -1390,6 +1402,11 @@ event_subscribe_ipc_cb_ (sdk::ipc::ipc_msg_ptr msg, const void *ctxt)
     sdk_ret_t ret;
     aga_event_subscribe_args_t *req;
 
+    if (events_disabled()) {
+        ret = SDK_RET_OK;
+        sdk::ipc::respond(msg, &ret, sizeof(ret));
+        return;
+    }
     req = *(aga_event_subscribe_args_t **)msg->data();
     if (req == NULL) {
         AGA_TRACE_ERR("Ignoring NULL event subscribe request received");
@@ -1475,6 +1492,11 @@ event_gen_ipc_cb_ (sdk::ipc::ipc_msg_ptr msg, const void *ctxt)
     sdk_ret_t ret;
     aga_event_gen_args_t *args;
 
+    if (events_disabled()) {
+        ret = SDK_RET_OK;
+        sdk::ipc::respond(msg, &ret, sizeof(ret));
+        return;
+    }
     args = (aga_event_gen_args_t *)msg->data();
     if (args == NULL) {
         AGA_TRACE_ERR("Ignoring NULL event generate request received");


### PR DESCRIPTION
## Motivation

Disable event monitoring using env variable

unit test
```bash
[root@05445856072d /]# ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root           1  0.0  0.0   4200  2764 ?        Ss   05:33   0:00 bash /home/amd/tools/entrypoint.sh
root           7  0.3  0.0 789760 25556 ?        Sl   05:33   0:00 /home/amd/bin/gpuagent -s /var/run/gpuagent.sock
root          18  0.1  0.0 1284800 37672 ?       Sl   05:33   0:00 /home/amd/bin/server
root          36  0.0  0.0   4852  2832 pts/0    Ss   05:33   0:00 bash
root          78  0.0  0.0   7444  2764 pts/0    R+   05:34   0:00 ps aux
[root@05445856072d /]# echo $GPUAGENT_EVENTS_DISABLE
1
[root@05445856072d /]# amd-smi process
GPU: 0
    PROCESS_INFO: No running processes detected

[root@05445856072d /]# gpuctl show gpu all | grep gpus
No. of gpus : 1
[root@05445856072d /]# gpuctl show events
Number of events: 0

```