### PR TITLE
fix(gpuagent): fix gfx/umc activity missing for partitioned GPUs

### DIFF
--- a/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
+++ b/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
@@ -1312,39 +1312,39 @@ smi_gpu_fill_stats (aga_gpu_handle_t gpu_handle,
         if (unlikely(amdsmi_ret != AMDSMI_STATUS_SUCCESS)) {
             AGA_TRACE_ERR("Failed to get GPU partition metrics info for GPU {}, "
                           "err {}", gpu_handle, amdsmi_ret);
-            return amdsmi_ret_to_sdk_ret(amdsmi_ret);
+            // fall through to g_gpu_metrics cache fallback below (partition 0 only)
+        } else {
+            // activity information
+            stats->usage.gfx_activity = metrics_info.average_gfx_activity;
+            stats->usage.umc_activity = metrics_info.average_umc_activity;
+            stats->usage.mm_activity = metrics_info.average_mm_activity;
+            stats->gfx_activity_accumulated = metrics_info.gfx_activity_acc;
+            stats->mem_activity_accumulated = metrics_info.mem_activity_acc;
+
+            // VCN busy stats (activity not available in partition mode)
+            for (uint16_t i = 0; i < AMDSMI_MAX_NUM_VCN; i++) {
+                stats->usage.vcn_busy[i] = metrics_info.xcp_stats[0].vcn_busy[i];
+            }
+
+            // JPEG busy stats (activity not available in partition mode)
+            for (uint16_t i = 0; i < AMDSMI_MAX_NUM_JPEG_ENG_V1; i++) {
+                stats->usage.jpeg_busy[i] = metrics_info.xcp_stats[0].jpeg_busy[i];
+            }
+
+            // GFX busy instances
+            for (uint16_t i = 0; i < AMDSMI_MAX_NUM_XCC; i++) {
+                stats->usage.gfx_busy_inst[i] =
+                    metrics_info.xcp_stats[0].gfx_busy_inst[i];
+            }
+
+            // fill violation stats for partitioned mode
+            smi_fill_violation_stats_(gpu_handle, partition_id,
+                                      &metrics_info,
+                                      &stats->violation_stats);
         }
-
-        // activity information
-        stats->usage.gfx_activity = metrics_info.average_gfx_activity;
-        stats->usage.umc_activity = metrics_info.average_umc_activity;
-        stats->usage.mm_activity = metrics_info.average_mm_activity;
-        stats->gfx_activity_accumulated = metrics_info.gfx_activity_acc;
-        stats->mem_activity_accumulated = metrics_info.mem_activity_acc;
-
-        // VCN busy stats (activity not available in partition mode)
-        for (uint16_t i = 0; i < AMDSMI_MAX_NUM_VCN; i++) {
-            stats->usage.vcn_busy[i] = metrics_info.xcp_stats[0].vcn_busy[i];
-        }
-
-        // JPEG busy stats (activity not available in partition mode)
-        for (uint16_t i = 0; i < AMDSMI_MAX_NUM_JPEG_ENG_V1; i++) {
-            stats->usage.jpeg_busy[i] = metrics_info.xcp_stats[0].jpeg_busy[i];
-        }
-
-        // GFX busy instances
-        for (uint16_t i = 0; i < AMDSMI_MAX_NUM_XCC; i++) {
-            stats->usage.gfx_busy_inst[i] =
-                metrics_info.xcp_stats[0].gfx_busy_inst[i];
-        }
-
-        // fill violation stats for partitioned mode
-        smi_fill_violation_stats_(gpu_handle, partition_id,
-                                  &metrics_info,
-                                  &stats->violation_stats);
     }
     // always fill for primary partition with cached metrics info,
-    // as primary partition metrics is not updated in new API
+    // as primary partition metrics is not updated in new API.
     if (!partition_id &&
         (g_gpu_metrics.find(gpu_handle) != g_gpu_metrics.end())) {
         metrics_info = g_gpu_metrics[gpu_handle];

--- a/sw/nic/gpuagent/init.cc
+++ b/sw/nic/gpuagent/init.cc
@@ -162,9 +162,10 @@ create_gpus (void)
         entry->set_id(gpu[i].id);
         // set GPU handle
         entry->set_handle(gpu[i].handle);
-        // num_parition is no more working in new library; derive it from
-        // compute partition type
-        if (gpu[i].compute_partition != AGA_GPU_COMPUTE_PARTITION_TYPE_SPX) {
+        // a GPU is partitioned only if it is a child of a parent GPU (i.e.
+        // it belongs to a genuinely partitioned device); non-partitioned GPUs
+        // and GPUs in SPX mode have no parent and must not be marked partitioned
+        if (parent_gpu) {
             // set partition state
             entry->set_is_partitioned();
         }


### PR DESCRIPTION
On MI250/MI308X with ROCm 7.2.1, amdsmi_get_gpu_partition_metrics_info() returns NOT_SUPPORTED (err 2). The old code returned early on this error, leaving gfx_activity/umc_activity at memset(0xFF) sentinel values, which DME's IsValueApplicable() then suppressed entirely.

Additionally, GPUs with compute_partition=NONE (e.g. MI210) were incorrectly marked as partitioned because the condition checked only != SPX. This caused them to enter the partitioned code path and hit the same NOT_SUPPORTED failure.

Fix:
- init.cc: use parent_gpu presence to detect partitioned GPUs instead of checking compute_partition type; treats NONE and SPX both as non-partitioned
- smi_api.cc: on partition metrics API failure, fall through to the g_gpu_metrics cache fallback instead of returning early; wrap the success path in else{} so fills only happen when the API succeeds
- Cache override applies only to partition 0 (!partition_id); partition 1+ uses the partition API result or stays suppressed if unsupported, matching amd-smi behavior (MI300X CPX shows no GFX activity for partition 1+ either)

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
