### PR TITLE
add new metrics with workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ gopkglist:
 
 .PHONY: gpuagent
 gpuagent:
-	docker run --rm -it --privileged \
+	docker run --rm --privileged \
 		--name ${CONTAINER_NAME} \
 		--network host \
 		-e "USER_NAME=$(shell whoami)" \
@@ -38,7 +38,7 @@ gpuagent:
 		-v $(CURDIR):$(CONTAINER_WORKDIR) \
 		-w $(CONTAINER_WORKDIR) \
 		${GPUAGENT_BLD_CONTAINER_IMAGE} \
-		bash -c " cd $(CONTAINER_WORKDIR) && source ~/.bashrc && git config --global --add safe.directory $(CONTAINER_WORKDIR) && make gopkglist && make -C sw/nic/gpuagent -j$(shell nproc)"
+		bash -c " cd $(CONTAINER_WORKDIR) && source ~/.bashrc && make gopkglist && make -C sw/nic/gpuagent all"
 
 .PHONY: docker-shell
 docker-shell:

--- a/sw/nic/gpuagent/api/include/aga_gpu.hpp
+++ b/sw/nic/gpuagent/api/include/aga_gpu.hpp
@@ -662,82 +662,122 @@ typedef struct aga_gpu_stats_s {
     uint64_t total_correctable_errors;
     /// total uncorrectable errors
     uint64_t total_uncorrectable_errors;
+    /// total deferred errors
+    uint64_t total_deferred_errors;
     /// SDMA correctable errors
     uint64_t sdma_correctable_errors;
     /// SDMA uncorrectable errors
     uint64_t sdma_uncorrectable_errors;
+    /// SDMA deferred errors
+    uint64_t sdma_deferred_errors;
     /// GFX correctable errors
     uint64_t gfx_correctable_errors;
     /// GFX uncorrectable errors
     uint64_t gfx_uncorrectable_errors;
+    /// GFX deferred errors
+    uint64_t gfx_deferred_errors;
     /// MMHUB correctable errors
     uint64_t mmhub_correctable_errors;
     /// MMHUB uncorrectable errors
     uint64_t mmhub_uncorrectable_errors;
+    /// MMHUB deferred errors
+    uint64_t mmhub_deferred_errors;
     /// ATHUB correctable errors
     uint64_t athub_correctable_errors;
     /// ATHUB uncorrectable errors
     uint64_t athub_uncorrectable_errors;
+    /// ATHUB deferred errors
+    uint64_t athub_deferred_errors;
     /// BIF correctable errors
     uint64_t bif_correctable_errors;
     /// BIF uncorrectable errors
     uint64_t bif_uncorrectable_errors;
+    /// BIF deferred errors
+    uint64_t bif_deferred_errors;
     /// HDP correctable errors
     uint64_t hdp_correctable_errors;
     /// HDP uncorrectable errors
     uint64_t hdp_uncorrectable_errors;
+    /// HDP deferred errors
+    uint64_t hdp_deferred_errors;
     /// XGMI WAFL correctable errors
     uint64_t xgmi_wafl_correctable_errors;
     /// XGMI WAFL uncorrectable errors
     uint64_t xgmi_wafl_uncorrectable_errors;
+    /// XGMI WAFL deferred errors
+    uint64_t xgmi_wafl_deferred_errors;
     /// DF correctable errors
     uint64_t df_correctable_errors;
     /// DF uncorrectable errors
     uint64_t df_uncorrectable_errors;
+    /// DF deferred errors
+    uint64_t df_deferred_errors;
     /// SMN correctable errors
     uint64_t smn_correctable_errors;
     /// SMN uncorrectable errors
     uint64_t smn_uncorrectable_errors;
+    /// SMN deferred errors
+    uint64_t smn_deferred_errors;
     /// SEM correctable errors
     uint64_t sem_correctable_errors;
     /// SEM uncorrectable errors
     uint64_t sem_uncorrectable_errors;
+    /// SEM deferred errors
+    uint64_t sem_deferred_errors;
     /// MP0 correctable errors
     uint64_t mp0_correctable_errors;
     /// MP0 uncorrectable errors
     uint64_t mp0_uncorrectable_errors;
+    /// MP0 deferred errors
+    uint64_t mp0_deferred_errors;
     /// MP1 correctable errors
     uint64_t mp1_correctable_errors;
     /// MP1 uncorrectable errors
     uint64_t mp1_uncorrectable_errors;
+    /// MP1 deferred errors
+    uint64_t mp1_deferred_errors;
     /// FUSE correctable errors
     uint64_t fuse_correctable_errors;
     /// FUSE uncorrectable errors
     uint64_t fuse_uncorrectable_errors;
+    /// FUSE deferred errors
+    uint64_t fuse_deferred_errors;
     /// UMC correctable errors
     uint64_t umc_correctable_errors;
     /// UMC uncorrectable errors
     uint64_t umc_uncorrectable_errors;
+    /// UMC deferred errors
+    uint64_t umc_deferred_errors;
     /// MCA correctable errors
     uint64_t mca_correctable_errors;
     /// MCA uncorrectable errors
     uint64_t mca_uncorrectable_errors;
+    /// MCA deferred errors
+    uint64_t mca_deferred_errors;
     /// VCN correctable errors
     uint64_t vcn_correctable_errors;
     /// VCN uncorrectable errors
     uint64_t vcn_uncorrectable_errors;
+    /// VCN deferred errors
+    uint64_t vcn_deferred_errors;
     /// JPEG correctable errors
     uint64_t jpeg_correctable_errors;
     /// JPEG uncorrectable errors
     uint64_t jpeg_uncorrectable_errors;
+    /// JPEG deferred errors
+    uint64_t jpeg_deferred_errors;
     /// IH correctable errors
     uint64_t ih_correctable_errors;
     /// IH uncorrectable errors
     uint64_t ih_uncorrectable_errors;
+    /// IH deferred errors
+    uint64_t ih_deferred_errors;
     /// MPIO correctable errors
     uint64_t mpio_correctable_errors;
     /// MPIO uncorrectable errors
     uint64_t mpio_uncorrectable_errors;
+    /// MPIO deferred errors
+    uint64_t mpio_deferred_errors;
     /// XGMI counters
     /// NOPs sent to neighbor0
     uint64_t xgmi_neighbor0_tx_nops;

--- a/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
+++ b/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
@@ -993,6 +993,7 @@ smi_fill_ecc_stats_ (aga_gpu_handle_t gpu_handle,
 {
     amdsmi_error_count_t ec;
     amdsmi_status_t amdsmi_ret;
+    uint64_t total_deferred_count = 0;
     uint64_t total_correctable_count = 0;
     uint64_t total_uncorrectable_count = 0;
     // get correctable and uncorrectable total error count beforehand
@@ -1005,120 +1006,159 @@ smi_fill_ecc_stats_ (aga_gpu_handle_t gpu_handle,
         if (amdsmi_ret == AMDSMI_STATUS_SUCCESS) {
             total_correctable_count += ec.correctable_count;
             total_uncorrectable_count += ec.uncorrectable_count;
+            total_deferred_count += ec.deferred_count;
             switch (b) {
             case AMDSMI_GPU_BLOCK_UMC:
                 stats->umc_correctable_errors =
                     ec.correctable_count;
                 stats->umc_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->umc_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_SDMA:
                 stats->sdma_correctable_errors =
                     ec.correctable_count;
                 stats->sdma_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->sdma_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_GFX:
                 stats->gfx_correctable_errors =
                     ec.correctable_count;
                 stats->gfx_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->gfx_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_MMHUB:
                 stats->mmhub_correctable_errors =
                     ec.correctable_count;
                 stats->mmhub_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->mmhub_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_ATHUB:
                 stats->athub_correctable_errors =
                     ec.correctable_count;
                 stats->athub_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->athub_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_PCIE_BIF:
                 stats->bif_correctable_errors =
                     ec.correctable_count;
                 stats->bif_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->bif_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_HDP:
                 stats->hdp_correctable_errors =
                     ec.correctable_count;
                 stats->hdp_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->hdp_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_XGMI_WAFL:
                 stats->xgmi_wafl_correctable_errors =
                     ec.correctable_count;
                 stats->xgmi_wafl_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->xgmi_wafl_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_DF:
                 stats->df_correctable_errors =
                     ec.correctable_count;
                 stats->df_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->df_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_SMN:
                 stats->smn_correctable_errors =
                     ec.correctable_count;
                 stats->smn_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->smn_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_SEM:
                 stats->sem_correctable_errors =
                     ec.correctable_count;
                 stats->sem_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->sem_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_MP0:
                 stats->mp0_correctable_errors =
                     ec.correctable_count;
                 stats->mp0_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->mp0_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_MP1:
                 stats->mp1_correctable_errors =
                     ec.correctable_count;
                 stats->mp1_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->mp1_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_FUSE:
                 stats->fuse_correctable_errors =
                     ec.correctable_count;
                 stats->fuse_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->fuse_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_MCA:
                 stats->mca_correctable_errors =
                     ec.correctable_count;
                 stats->mca_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->mca_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_VCN:
                 stats->vcn_correctable_errors =
                     ec.correctable_count;
                 stats->vcn_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->vcn_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_JPEG:
                 stats->jpeg_correctable_errors =
                     ec.correctable_count;
                 stats->jpeg_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->jpeg_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_IH:
                 stats->ih_correctable_errors =
                     ec.correctable_count;
                 stats->ih_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->ih_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_MPIO:
                 stats->mpio_correctable_errors =
                     ec.correctable_count;
                 stats->mpio_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->mpio_deferred_errors =
+                    ec.deferred_count;
                 break;
             default:
                 break;
@@ -1127,6 +1167,7 @@ smi_fill_ecc_stats_ (aga_gpu_handle_t gpu_handle,
     }
     stats->total_correctable_errors = total_correctable_count;
     stats->total_uncorrectable_errors = total_uncorrectable_count;
+    stats->total_deferred_errors = total_deferred_count;
 }
 
 static sdk_ret_t

--- a/sw/nic/gpuagent/api/smi/gimamdsmi/smi_api.cc
+++ b/sw/nic/gpuagent/api/smi/gimamdsmi/smi_api.cc
@@ -605,6 +605,7 @@ smi_fill_ecc_stats_ (aga_gpu_handle_t gpu_handle,
 {
     amdsmi_error_count_t ec;
     amdsmi_status_t amdsmi_ret;
+    uint64_t total_deferred_count = 0;
     uint64_t total_correctable_count = 0;
     uint64_t total_uncorrectable_count = 0;
     // get correctable and uncorrectable total error count beforehand
@@ -617,120 +618,159 @@ smi_fill_ecc_stats_ (aga_gpu_handle_t gpu_handle,
         if (amdsmi_ret == AMDSMI_STATUS_SUCCESS) {
             total_correctable_count += ec.correctable_count;
             total_uncorrectable_count += ec.uncorrectable_count;
+            total_deferred_count += ec.deferred_count;
             switch (b) {
             case AMDSMI_GPU_BLOCK_UMC:
                 stats->umc_correctable_errors =
                     ec.correctable_count;
                 stats->umc_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->umc_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_SDMA:
                 stats->sdma_correctable_errors =
                     ec.correctable_count;
                 stats->sdma_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->sdma_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_GFX:
                 stats->gfx_correctable_errors =
                     ec.correctable_count;
                 stats->gfx_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->gfx_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_MMHUB:
                 stats->mmhub_correctable_errors =
                     ec.correctable_count;
                 stats->mmhub_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->mmhub_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_ATHUB:
                 stats->athub_correctable_errors =
                     ec.correctable_count;
                 stats->athub_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->athub_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_PCIE_BIF:
                 stats->bif_correctable_errors =
                     ec.correctable_count;
                 stats->bif_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->bif_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_HDP:
                 stats->hdp_correctable_errors =
                     ec.correctable_count;
                 stats->hdp_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->hdp_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_XGMI_WAFL:
                 stats->xgmi_wafl_correctable_errors =
                     ec.correctable_count;
                 stats->xgmi_wafl_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->xgmi_wafl_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_DF:
                 stats->df_correctable_errors =
                     ec.correctable_count;
                 stats->df_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->df_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_SMN:
                 stats->smn_correctable_errors =
                     ec.correctable_count;
                 stats->smn_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->smn_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_SEM:
                 stats->sem_correctable_errors =
                     ec.correctable_count;
                 stats->sem_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->sem_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_MP0:
                 stats->mp0_correctable_errors =
                     ec.correctable_count;
                 stats->mp0_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->mp0_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_MP1:
                 stats->mp1_correctable_errors =
                     ec.correctable_count;
                 stats->mp1_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->mp1_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_FUSE:
                 stats->fuse_correctable_errors =
                     ec.correctable_count;
                 stats->fuse_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->fuse_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_MCA:
                 stats->mca_correctable_errors =
                     ec.correctable_count;
                 stats->mca_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->mca_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_VCN:
                 stats->vcn_correctable_errors =
                     ec.correctable_count;
                 stats->vcn_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->vcn_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_JPEG:
                 stats->jpeg_correctable_errors =
                     ec.correctable_count;
                 stats->jpeg_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->jpeg_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_IH:
                 stats->ih_correctable_errors =
                     ec.correctable_count;
                 stats->ih_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->ih_deferred_errors =
+                    ec.deferred_count;
                 break;
             case AMDSMI_GPU_BLOCK_MPIO:
                 stats->mpio_correctable_errors =
                     ec.correctable_count;
                 stats->mpio_uncorrectable_errors =
                     ec.uncorrectable_count;
+                stats->mpio_deferred_errors =
+                    ec.deferred_count;
                 break;
             default:
                 break;
@@ -739,6 +779,7 @@ smi_fill_ecc_stats_ (aga_gpu_handle_t gpu_handle,
     }
     stats->total_correctable_errors = total_correctable_count;
     stats->total_uncorrectable_errors = total_uncorrectable_count;
+    stats->total_deferred_errors = total_deferred_count;
 }
 
 sdk_ret_t

--- a/sw/nic/gpuagent/cli/cmd/gpu.go
+++ b/sw/nic/gpuagent/cli/cmd/gpu.go
@@ -1414,6 +1414,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 		fmt.Printf(indent+"%-38s : %d\n", "Total uncorrectable errors",
 			stats.GetTotalUncorrectableErrors())
 	}
+	if stats.GetTotalDeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "Total deferred errors",
+			stats.GetTotalDeferredErrors())
+	}
 	if stats.GetSDMACorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "SDMA correctable errors",
 			stats.GetSDMACorrectableErrors())
@@ -1421,6 +1425,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 	if stats.GetSDMAUncorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "SDMA uncorrectable errors",
 			stats.GetSDMAUncorrectableErrors())
+	}
+	if stats.GetSDMADeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "SDMA deferred errors",
+			stats.GetSDMADeferredErrors())
 	}
 	if stats.GetGFXCorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "GFX correctable errors",
@@ -1430,6 +1438,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 		fmt.Printf(indent+"%-38s : %d\n", "GFX uncorrectable errors",
 			stats.GetGFXUncorrectableErrors())
 	}
+	if stats.GetGFXDeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "GFX deferred errors",
+			stats.GetGFXDeferredErrors())
+	}
 	if stats.GetMMHUBCorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "MMHUB correctable errors",
 			stats.GetMMHUBCorrectableErrors())
@@ -1437,6 +1449,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 	if stats.GetMMHUBUncorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "MMHUB uncorrectable errors",
 			stats.GetMMHUBUncorrectableErrors())
+	}
+	if stats.GetMMHUBDeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "MMHUB deferred errors",
+			stats.GetMMHUBDeferredErrors())
 	}
 	if stats.GetATHUBCorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "ATHUB correctable errors",
@@ -1446,6 +1462,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 		fmt.Printf(indent+"%-38s : %d\n", "ATHUB uncorrectable errors",
 			stats.GetATHUBUncorrectableErrors())
 	}
+	if stats.GetATHUBDeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "ATHUB deferred errors",
+			stats.GetATHUBDeferredErrors())
+	}
 	if stats.GetBIFCorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "BIF correctable errors",
 			stats.GetBIFCorrectableErrors())
@@ -1453,6 +1473,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 	if stats.GetBIFUncorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "BIF uncorrectable errors",
 			stats.GetBIFUncorrectableErrors())
+	}
+	if stats.GetBIFDeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "BIF deferred errors",
+			stats.GetBIFDeferredErrors())
 	}
 	if stats.GetHDPCorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "HDP correctable errors",
@@ -1462,6 +1486,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 		fmt.Printf(indent+"%-38s : %d\n", "HDP uncorrectable errors",
 			stats.GetHDPUncorrectableErrors())
 	}
+	if stats.GetHDPDeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "HDP deferred errors",
+			stats.GetHDPDeferredErrors())
+	}
 	if stats.GetXGMIWAFLCorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "XGMI WAFL correctable errors",
 			stats.GetXGMIWAFLCorrectableErrors())
@@ -1469,6 +1497,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 	if stats.GetXGMIWAFLUncorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "XGMI WAFL uncorrectable errors",
 			stats.GetXGMIWAFLUncorrectableErrors())
+	}
+	if stats.GetXGMIWAFLDeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "XGMI WAFL deferred errors",
+			stats.GetXGMIWAFLDeferredErrors())
 	}
 	if stats.GetDFCorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "DF correctable errors",
@@ -1478,6 +1510,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 		fmt.Printf(indent+"%-38s : %d\n", "DF uncorrectable errors",
 			stats.GetDFUncorrectableErrors())
 	}
+	if stats.GetDFDeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "DF deferred errors",
+			stats.GetDFDeferredErrors())
+	}
 	if stats.GetSMNCorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "SMN correctable errors",
 			stats.GetSMNCorrectableErrors())
@@ -1485,6 +1521,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 	if stats.GetSMNUncorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "SMN uncorrectable errors",
 			stats.GetSMNUncorrectableErrors())
+	}
+	if stats.GetSMNDeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "SMN deferred errors",
+			stats.GetSMNDeferredErrors())
 	}
 	if stats.GetSEMCorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "SEM correctable errors",
@@ -1494,6 +1534,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 		fmt.Printf(indent+"%-38s : %d\n", "SEM uncorrectable errors",
 			stats.GetSEMUncorrectableErrors())
 	}
+	if stats.GetSEMDeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "SEM deferred errors",
+			stats.GetSEMDeferredErrors())
+	}
 	if stats.GetMP0CorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "MP0 correctable errors",
 			stats.GetMP0CorrectableErrors())
@@ -1501,6 +1545,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 	if stats.GetMP0UncorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "MP0 uncorrectable errors",
 			stats.GetMP0UncorrectableErrors())
+	}
+	if stats.GetMP0DeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "MP0 deferred errors",
+			stats.GetMP0DeferredErrors())
 	}
 	if stats.GetMP1CorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "MP1 correctable errors",
@@ -1510,6 +1558,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 		fmt.Printf(indent+"%-38s : %d\n", "MP1 uncorrectable errors",
 			stats.GetMP1UncorrectableErrors())
 	}
+	if stats.GetMP1DeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "MP1 deferred errors",
+			stats.GetMP1DeferredErrors())
+	}
 	if stats.GetFUSECorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "FUSE correctable errors",
 			stats.GetFUSECorrectableErrors())
@@ -1517,6 +1569,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 	if stats.GetFUSEUncorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "FUSE uncorrectable errors",
 			stats.GetFUSEUncorrectableErrors())
+	}
+	if stats.GetFUSEDeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "FUSE deferred errors",
+			stats.GetFUSEDeferredErrors())
 	}
 	if stats.GetUMCCorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "UMC correctable errors",
@@ -1526,6 +1582,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 		fmt.Printf(indent+"%-38s : %d\n", "UMC uncorrectable errors",
 			stats.GetUMCUncorrectableErrors())
 	}
+	if stats.GetUMCDeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "UMC deferred errors",
+			stats.GetUMCDeferredErrors())
+	}
 	if stats.GetMCACorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "MCA correctable errors",
 			stats.GetMCACorrectableErrors())
@@ -1533,6 +1593,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 	if stats.GetMCAUncorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "MCA uncorrectable errors",
 			stats.GetMCAUncorrectableErrors())
+	}
+	if stats.GetMCADeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "MCA deferred errors",
+			stats.GetMCADeferredErrors())
 	}
 	if stats.GetVCNCorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "VCN correctable errors",
@@ -1542,6 +1606,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 		fmt.Printf(indent+"%-38s : %d\n", "VCN uncorrectable errors",
 			stats.GetVCNUncorrectableErrors())
 	}
+	if stats.GetVCNDeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "VCN deferred errors",
+			stats.GetVCNDeferredErrors())
+	}
 	if stats.GetJPEGCorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "JPEG correctable errors",
 			stats.GetJPEGCorrectableErrors())
@@ -1549,6 +1617,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 	if stats.GetJPEGUncorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "JPEG uncorrectable errors",
 			stats.GetJPEGUncorrectableErrors())
+	}
+	if stats.GetJPEGDeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "JPEG deferred errors",
+			stats.GetJPEGDeferredErrors())
 	}
 	if stats.GetIHCorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "IH correctable errors",
@@ -1558,6 +1630,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 		fmt.Printf(indent+"%-38s : %d\n", "IH uncorrectable errors",
 			stats.GetIHUncorrectableErrors())
 	}
+	if stats.GetIHDeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "IH deferred errors",
+			stats.GetIHDeferredErrors())
+	}
 	if stats.GetMPIOCorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "MPIO correctable errors",
 			stats.GetMPIOCorrectableErrors())
@@ -1565,6 +1641,10 @@ func printGPUStats(gpu *aga.GPU, statsOnly bool) {
 	if stats.GetMPIOUncorrectableErrors() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "MPIO uncorrectable errors",
 			stats.GetMPIOUncorrectableErrors())
+	}
+	if stats.GetMPIODeferredErrors() != 0 {
+		fmt.Printf(indent+"%-38s : %d\n", "MPIO deferred errors",
+			stats.GetMPIODeferredErrors())
 	}
 	if stats.GetXGMINeighbor0TxNOPs() != 0 {
 		fmt.Printf(indent+"%-38s : %d\n", "Nops sent to XGMI neighbor0",

--- a/sw/nic/gpuagent/protos/gpu.proto
+++ b/sw/nic/gpuagent/protos/gpu.proto
@@ -755,6 +755,46 @@ message GPUStats {
   repeated GPUXGMILinkStats  XGMILinkStats               = 67;
   // GPU violation statistics
   GPUViolationStats          ViolationStats              = 68;
+  // Total deferred errors across all blocks
+  uint64                     TotalDeferredErrors         = 69;
+  // SDMA deferred errors
+  uint64                     SDMADeferredErrors          = 70;
+  // GFX deferred errors
+  uint64                     GFXDeferredErrors           = 71;
+  // MMHUB deferred errors
+  uint64                     MMHUBDeferredErrors         = 72;
+  // ATHUB deferred errors
+  uint64                     ATHUBDeferredErrors         = 73;
+  // BIF deferred errors
+  uint64                     BIFDeferredErrors           = 74;
+  // HDP deferred errors
+  uint64                     HDPDeferredErrors           = 75;
+  // XGMI WAFL deferred errors
+  uint64                     XGMIWAFLDeferredErrors      = 76;
+  // DF deferred errors
+  uint64                     DFDeferredErrors            = 77;
+  // SMN deferred errors
+  uint64                     SMNDeferredErrors           = 78;
+  // SEM deferred errors
+  uint64                     SEMDeferredErrors           = 79;
+  // MP0 deferred errors
+  uint64                     MP0DeferredErrors           = 80;
+  // MP1 deferred errors
+  uint64                     MP1DeferredErrors           = 81;
+  // FUSE deferred errors
+  uint64                     FUSEDeferredErrors          = 82;
+  // UMC deferred errors
+  uint64                     UMCDeferredErrors           = 83;
+  // MCA deferred errors
+  uint64                     MCADeferredErrors           = 84;
+  // VCN deferred errors
+  uint64                     VCNDeferredErrors           = 85;
+  // JPEG deferred errors
+  uint64                     JPEGDeferredErrors          = 86;
+  // IH deferred errors
+  uint64                     IHDeferredErrors            = 87;
+  // MPIO deferred errors
+  uint64                     MPIODeferredErrors          = 88;
 }
 
 // GPU captures config, operational status and stat of GPU object

--- a/sw/nic/gpuagent/svc/gpu_to_proto.hpp
+++ b/sw/nic/gpuagent/svc/gpu_to_proto.hpp
@@ -694,48 +694,68 @@ aga_gpu_api_stats_to_proto (GPUStats *proto_stats,
     proto_stats->set_totalcorrectableerrors(stats->total_correctable_errors);
     proto_stats->set_totaluncorrectableerrors(
                      stats->total_uncorrectable_errors);
+    proto_stats->set_totaldeferrederrors(stats->total_deferred_errors);
     proto_stats->set_sdmacorrectableerrors(stats->sdma_correctable_errors);
     proto_stats->set_sdmauncorrectableerrors(stats->sdma_uncorrectable_errors);
+    proto_stats->set_sdmadeferrederrors(stats->sdma_deferred_errors);
     proto_stats->set_gfxcorrectableerrors(stats->gfx_correctable_errors);
     proto_stats->set_gfxuncorrectableerrors(stats->gfx_uncorrectable_errors);
+    proto_stats->set_gfxdeferrederrors(stats->gfx_deferred_errors);
     proto_stats->set_mmhubcorrectableerrors(stats->mmhub_correctable_errors);
     proto_stats->set_mmhubuncorrectableerrors(
                      stats->mmhub_uncorrectable_errors);
+    proto_stats->set_mmhubdeferrederrors(stats->mmhub_deferred_errors);
     proto_stats->set_athubcorrectableerrors(stats->athub_correctable_errors);
     proto_stats->set_athubuncorrectableerrors(
                      stats->athub_uncorrectable_errors);
+    proto_stats->set_athubdeferrederrors(stats->athub_deferred_errors);
     proto_stats->set_bifcorrectableerrors(stats->bif_correctable_errors);
     proto_stats->set_bifuncorrectableerrors(stats->bif_uncorrectable_errors);
+    proto_stats->set_bifdeferrederrors(stats->bif_deferred_errors);
     proto_stats->set_hdpcorrectableerrors(stats->hdp_correctable_errors);
     proto_stats->set_hdpuncorrectableerrors(stats->hdp_uncorrectable_errors);
+    proto_stats->set_hdpdeferrederrors(stats->hdp_deferred_errors);
     proto_stats->set_xgmiwaflcorrectableerrors(
                      stats->xgmi_wafl_correctable_errors);
     proto_stats->set_xgmiwafluncorrectableerrors(
                      stats->xgmi_wafl_uncorrectable_errors);
+    proto_stats->set_xgmiwafldeferrederrors(stats->xgmi_wafl_deferred_errors);
     proto_stats->set_dfcorrectableerrors(stats->df_correctable_errors);
     proto_stats->set_dfuncorrectableerrors(stats->df_uncorrectable_errors);
+    proto_stats->set_dfdeferrederrors(stats->df_deferred_errors);
     proto_stats->set_smncorrectableerrors(stats->smn_correctable_errors);
     proto_stats->set_smnuncorrectableerrors(stats->smn_uncorrectable_errors);
+    proto_stats->set_smndeferrederrors(stats->smn_deferred_errors);
     proto_stats->set_semcorrectableerrors(stats->sem_correctable_errors);
     proto_stats->set_semuncorrectableerrors(stats->sem_uncorrectable_errors);
+    proto_stats->set_semdeferrederrors(stats->sem_deferred_errors);
     proto_stats->set_mp0correctableerrors(stats->mp0_correctable_errors);
     proto_stats->set_mp0uncorrectableerrors(stats->mp0_uncorrectable_errors);
+    proto_stats->set_mp0deferrederrors(stats->mp0_deferred_errors);
     proto_stats->set_mp1correctableerrors(stats->mp1_correctable_errors);
     proto_stats->set_mp1uncorrectableerrors(stats->mp1_uncorrectable_errors);
+    proto_stats->set_mp1deferrederrors(stats->mp1_deferred_errors);
     proto_stats->set_fusecorrectableerrors(stats->fuse_correctable_errors);
     proto_stats->set_fuseuncorrectableerrors(stats->fuse_uncorrectable_errors);
+    proto_stats->set_fusedeferrederrors(stats->fuse_deferred_errors);
     proto_stats->set_umccorrectableerrors(stats->umc_correctable_errors);
     proto_stats->set_umcuncorrectableerrors(stats->umc_uncorrectable_errors);
+    proto_stats->set_umcdeferrederrors(stats->umc_deferred_errors);
     proto_stats->set_mcacorrectableerrors(stats->mca_correctable_errors);
     proto_stats->set_mcauncorrectableerrors(stats->mca_uncorrectable_errors);
+    proto_stats->set_mcadeferrederrors(stats->mca_deferred_errors);
     proto_stats->set_vcncorrectableerrors(stats->vcn_correctable_errors);
     proto_stats->set_vcnuncorrectableerrors(stats->vcn_uncorrectable_errors);
+    proto_stats->set_vcndeferrederrors(stats->vcn_deferred_errors);
     proto_stats->set_jpegcorrectableerrors(stats->jpeg_correctable_errors);
     proto_stats->set_jpeguncorrectableerrors(stats->jpeg_uncorrectable_errors);
+    proto_stats->set_jpegdeferrederrors(stats->jpeg_deferred_errors);
     proto_stats->set_ihcorrectableerrors(stats->ih_correctable_errors);
     proto_stats->set_ihuncorrectableerrors(stats->ih_uncorrectable_errors);
+    proto_stats->set_ihdeferrederrors(stats->ih_deferred_errors);
     proto_stats->set_mpiocorrectableerrors(stats->mpio_correctable_errors);
     proto_stats->set_mpiouncorrectableerrors(stats->mpio_uncorrectable_errors);
+    proto_stats->set_mpiodeferrederrors(stats->mpio_deferred_errors);
     proto_stats->set_xgmineighbor0txnops(stats->xgmi_neighbor0_tx_nops);
     proto_stats->set_xgmineighbor0txrequests(stats->xgmi_neighbor0_tx_requests);
     proto_stats->set_xgmineighbor0txresponses


### PR DESCRIPTION
## Motivation

Add new ecc deffered metric support

```bash
[root@default-metrics-exporter-sb78f ~]# gpuctl show gpu -y | grep def
    totaldeferrederrors: 0
    sdmadeferrederrors: 0
    gfxdeferrederrors: 0
    mmhubdeferrederrors: 0
    athubdeferrederrors: 0
    bifdeferrederrors: 0
    hdpdeferrederrors: 0
    xgmiwafldeferrederrors: 0
    dfdeferrederrors: 0
    smndeferrederrors: 0
    semdeferrederrors: 0
    mp0deferrederrors: 0
    mp1deferrederrors: 0
    fusedeferrederrors: 0
    umcdeferrederrors: 0
    mcadeferrederrors: 0
    vcndeferrederrors: 0
    jpegdeferrederrors: 0
    ihdeferrederrors: 0
    mpiodeferrederrors: 0

```