### PR TITLE
GPUAgent - add cli to dump gpuagent and gpuctl version

### DIFF
--- a/sw/nic/gpuagent/Makefile
+++ b/sw/nic/gpuagent/Makefile
@@ -47,6 +47,10 @@ export GRPC_PY_PLUGIN        := ${BLD_BIN_DIR}/grpc_python_plugin
 export PROTOC_LIB_PATH       := ${BLD_DIR}/lib
 export OTHER_THIRD_PARTY_INC ?= ${SPDLOG_INC_DIR} ${GFLAGS_INC_DIR} ${GRPC_INCLUDE}
 
+GIT_COMMIT                   ?= $(shell git rev-list -1 HEAD --abbrev-commit)
+GIT_BRANCH                   ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+GPUAGENT_VERSION             ?= $(GIT_BRANCH)-$(GIT_COMMIT)
+
 TARGET                       := gpuagent
 EXCLUDE_DIRS                 := $(TOPDIR)/nic/third-party
 EXCLUDE_VENDOR               := $(ABS_DIR)/nic/gpuagent/vendor
@@ -212,7 +216,7 @@ gen-protos:
 
 gpuctl:
 	@echo "building gpuctl"
-	CGO_ENABLED=0 go build -C cli -o ${BLD_BIN_DIR}/gpuctl
+	CGO_ENABLED=0 go build -C cli -ldflags="-s -w -X github.com/ROCm/gpu-agent/sw/nic/gpuagent/cli/cmd.GpuctlVersion=$(GPUAGENT_VERSION)" -o ${BLD_BIN_DIR}/gpuctl
 
 gogo-protos:
 	@mkdir -p ${BLD_PROTOGEN_DIR}
@@ -220,27 +224,27 @@ gogo-protos:
 
 $(OBJ_DIR)/%.o: $(TOPDIR)/%.cc
 	@mkdir -p $(dir $@)  # Create the necessary subdirectories in temp
-	$(CC) $(CFLAGS) $(DEFS) $(INCS_AMD_SMI) -DAMD_SMI -D__FNAME__=__FILE__ -c $< -o $@
+	$(CC) $(CFLAGS) $(DEFS) $(INCS_AMD_SMI) -DAMD_SMI -D__FNAME__=__FILE__ -DGPUAGENT_VERSION=\"$(GPUAGENT_VERSION)\" -c $< -o $@
 
 $(OBJ_DIR)/%.o: $(TOPDIR)/%.c
 	@mkdir -p $(dir $@)  # Create the necessary subdirectories in temp
-	$(CC) $(CFLAGS)  $(INCS_AMD_SMI) -DAMD_SMI -D__FNAME__=__FILE__ -c $< -o $@
+	$(CC) $(CFLAGS)  $(INCS_AMD_SMI) -DAMD_SMI -D__FNAME__=__FILE__ -DGPUAGENT_VERSION=\"$(GPUAGENT_VERSION)\" -c $< -o $@
 
 $(OBJ_DIR_GIM)/%.o: $(TOPDIR)/%.cc
 	@mkdir -p $(dir $@)  # Create the necessary subdirectories in temp
-	$(CC) $(CFLAGS) $(DEFS) $(INCS_GIM_SMI) -DGIM_AMD_SMI -D__FNAME__=__FILE__ -c $< -o $@
+	$(CC) $(CFLAGS) $(DEFS) $(INCS_GIM_SMI) -DGIM_AMD_SMI -D__FNAME__=__FILE__ -DGPUAGENT_VERSION=\"$(GPUAGENT_VERSION)\" -c $< -o $@
 
 $(OBJ_DIR_GIM)/%.o: $(TOPDIR)/%.c
 	@mkdir -p $(dir $@)  # Create the necessary subdirectories in temp
-	$(CC) $(CFLAGS)  $(INCS_GIM_SMI) -DGIM_AMD_SMI -D__FNAME__=__FILE__ -c $< -o $@
+	$(CC) $(CFLAGS)  $(INCS_GIM_SMI) -DGIM_AMD_SMI -D__FNAME__=__FILE__ -DGPUAGENT_VERSION=\"$(GPUAGENT_VERSION)\" -c $< -o $@
 
 $(OBJ_DIR_MOCK)/%.o: $(TOPDIR)/%.cc
 	@mkdir -p $(dir $@)  # Create the necessary subdirectories in temp
-	$(CC) $(CFLAGS) $(DEFS) $(INCS_MOCK) -DAMD_SMI -D__FNAME__=__FILE__ -c $< -o $@
+	$(CC) $(CFLAGS) $(DEFS) $(INCS_MOCK) -DAMD_SMI -D__FNAME__=__FILE__ -DGPUAGENT_VERSION=\"$(GPUAGENT_VERSION)\" -c $< -o $@
 
 $(OBJ_DIR_MOCK)/%.o: $(TOPDIR)/%.c
 	@mkdir -p $(dir $@)  # Create the necessary subdirectories in temp
-	$(CC) $(CFLAGS)  $(INCS_MOCK) -DAMD_SMI -D__FNAME__=__FILE__ -c $< -o $@
+	$(CC) $(CFLAGS)  $(INCS_MOCK) -DAMD_SMI -D__FNAME__=__FILE__ -DGPUAGENT_VERSION=\"$(GPUAGENT_VERSION)\" -c $< -o $@
 
 clean:
 	rm -rf $(BLD_BIN_DIR) $(OBJ_DIR) $(OBJ_DIR_GIM) $(OBJ_DIR_MOCK) $(BLD_PROTOGEN_DIR); \

--- a/sw/nic/gpuagent/api/include/base.hpp
+++ b/sw/nic/gpuagent/api/include/base.hpp
@@ -32,6 +32,10 @@ limitations under the License.
 #include <arpa/inet.h>
 #include <unistd.h>
 
+#ifndef GPUAGENT_VERSION
+#define GPUAGENT_VERSION    "unknown"
+#endif
+
 // TODO:
 // 1. rename this to aga_base.hpp ??
 // 2. move this to core/

--- a/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
+++ b/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
@@ -1168,6 +1168,7 @@ smi_fill_ecc_stats_ (aga_gpu_handle_t gpu_handle,
     stats->total_correctable_errors = total_correctable_count;
     stats->total_uncorrectable_errors = total_uncorrectable_count;
     stats->total_deferred_errors = total_deferred_count;
+    return SDK_RET_OK;
 }
 
 static sdk_ret_t

--- a/sw/nic/gpuagent/cli/cmd/version.go
+++ b/sw/nic/gpuagent/cli/cmd/version.go
@@ -1,0 +1,78 @@
+//
+// Copyright(C) Advanced Micro Devices, Inc. All rights reserved.
+//
+// You may not use this software and documentation (if any) (collectively,
+// the "Materials") except in compliance with the terms and conditions of
+// the Software License Agreement included with the Materials or otherwise as
+// set forth in writing and signed by you and an authorized signatory of AMD.
+// If you do not have a copy of the Software License Agreement, contact your
+// AMD representative for a copy.
+//
+// You agree that you will not reverse engineer or decompile the Materials,
+// in whole or in part, except as allowed by applicable law.
+//
+// THE MATERIALS ARE DISTRIBUTED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR
+// REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
+//
+
+//------------------------------------------------------------------------------
+///
+/// \file
+/// gpuctl command line interface for version
+///
+//------------------------------------------------------------------------------
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ROCm/gpu-agent/sw/nic/gpuagent/cli/utils"
+	aga "github.com/ROCm/gpu-agent/sw/nic/gpuagent/gen/go"
+)
+
+var (
+	// GpuctlVersion is set at build time via ldflags
+	GpuctlVersion = "unknown"
+)
+
+var versionShowCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show version information",
+	Long:  "Display gpuctl and gpuagent version",
+	RunE:  versionShowCmdHandler,
+}
+
+func versionShowCmdHandler(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("Invalid argument")
+	}
+	if cmd != nil {
+		cmd.SilenceUsage = true
+	}
+	fmt.Printf("%-10s: %s\n", "gpuctl", GpuctlVersion)
+	// connect to GPU agent
+	c, ctxt, cancel, err := utils.CreateNewAGAGRPClient()
+	if err != nil {
+		return fmt.Errorf("Could not connect to the GPU agent, is agent " +
+			"running?")
+	}
+	defer c.Close()
+	defer cancel()
+
+	client := aga.NewDebugSvcClient(c)
+
+	req := &aga.Empty{}
+	resp, err := client.VersionGet(ctxt, req)
+	if err != nil {
+		return fmt.Errorf("Getting gpuagent version failed, err %v", err)
+	}
+	fmt.Printf("%-10s: %s\n", "gpuagent", resp.GetVersion())
+	return nil
+}
+
+func init() {
+	ShowCmd.AddCommand(versionShowCmd)
+}

--- a/sw/nic/gpuagent/protos/debug.proto
+++ b/sw/nic/gpuagent/protos/debug.proto
@@ -36,6 +36,8 @@ service DebugSvc {
   rpc TraceFlush(types.Empty) returns (types.Empty) {}
   // API to query the tracing related configuration
   rpc TraceGet (types.Empty) returns (TraceGetResponse) {}
+  // API to query the version of GPUAgent
+  rpc VersionGet (types.Empty) returns (VersionGetResponse) {}
 }
 
 // supported trace levels
@@ -77,4 +79,10 @@ message TraceGetResponse {
   string     TraceFile  = 2;
   // API trace enabled/disabled
   bool       ApiTraceEn = 3;
+}
+
+// GPUAgent version get response message
+message VersionGetResponse {
+  // GPUAgent version
+  string Version = 1;
 }

--- a/sw/nic/gpuagent/svc/debug.cc
+++ b/sw/nic/gpuagent/svc/debug.cc
@@ -25,6 +25,7 @@ limitations under the License.
 
 #include "nic/gpuagent/core/trace.hpp"
 #include "nic/gpuagent/svc/debug.hpp"
+#include "nic/gpuagent/api/include/base.hpp"
 
 Status
 DebugSvcImpl::TraceUpdate(ServerContext *context,
@@ -101,5 +102,12 @@ Status
 DebugSvcImpl::TraceFlush(ServerContext *context, const Empty *req,
                          Empty *rsp) {
     core::flush_logs();
+    return Status::OK;
+}
+
+Status
+DebugSvcImpl::VersionGet(ServerContext *context, const Empty *req,
+                         VersionGetResponse *rsp) {
+    rsp->set_version(GPUAGENT_VERSION);
     return Status::OK;
 }

--- a/sw/nic/gpuagent/svc/debug.hpp
+++ b/sw/nic/gpuagent/svc/debug.hpp
@@ -39,6 +39,7 @@ using types::Empty;
 using amdgpu::TraceRequest;
 using amdgpu::TraceResponse;
 using amdgpu::TraceGetResponse;
+using amdgpu::VersionGetResponse;
 
 class DebugSvcImpl final : public DebugSvc::Service {
 public:
@@ -48,6 +49,8 @@ public:
                          TraceGetResponse *rsp) override;
     Status TraceFlush(ServerContext *context, const Empty *req,
                       Empty *rsp) override;
+    Status VersionGet(ServerContext *context, const Empty *req,
+                      VersionGetResponse *rsp) override;
 };
 
 #endif    // __AGA_SVC_DEBUG_HPP__


### PR DESCRIPTION
## Motivation

Add versions to gpuagent and gpuctl, add cli to expose it

```
root@leto:/home/amd# ./gpuctl show version --node-svc-port 60000
gpuctl    : version-cli-afbada1
gpuagent  : version-cli-afbada1