### PR TITLE
feat(gpuagent): teardown SMI connections on SIGTERM/SIGINT/SIGABRT/SI…

### DIFF
--- a/sw/nic/gpuagent/api/init.cc
+++ b/sw/nic/gpuagent/api/init.cc
@@ -42,7 +42,7 @@ aga_api_init (aga_api_init_params_t *init_params)
     while (!aga::is_api_thread_ready()) {
         sched_yield();
     }
-    // initialize rocm-smi library
+    // initialize SMI library
     ret = aga::smi_init(init_params);
     if (unlikely(ret != SDK_RET_OK)) {
         AGA_TRACE_ERR("Failed to initialize smi library, err {}", ret());
@@ -54,5 +54,7 @@ aga_api_init (aga_api_init_params_t *init_params)
 sdk_ret_t
 aga_api_teardown (void)
 {
+    // teardown SMI library
+    aga::smi_teardown();
     return SDK_RET_OK;
 }

--- a/sw/nic/gpuagent/api/smi/amdsmi/smi_state.cc
+++ b/sw/nic/gpuagent/api/smi/amdsmi/smi_state.cc
@@ -1573,6 +1573,29 @@ smi_state::init(aga_api_init_params_t *init_params) {
     spawn_event_monitor_thread_();
     // spawn watcher thread
     spawn_watcher_thread_();
+    initialized_ = true;
+    return SDK_RET_OK;
+}
+
+sdk_ret_t
+smi_state::teardown (void)
+{
+    amdsmi_status_t status;
+
+    if (!initialized_) {
+        return SDK_RET_OK;
+    }
+    // stop the watcher thread before shutting down the SMI library to
+    // avoid racing with the watcher timer callback which calls SMI APIs
+    if (watcher_thread_) {
+        watcher_thread_->stop();
+        watcher_thread_->wait();
+    }
+    status = amdsmi_shut_down();
+    if (unlikely(status != AMDSMI_STATUS_SUCCESS)) {
+        AGA_TRACE_ERR("Failed to shutdown amd smi library, err {}", status);
+        return amdsmi_ret_to_sdk_ret(status);
+    }
     return SDK_RET_OK;
 }
 

--- a/sw/nic/gpuagent/api/smi/gimamdsmi/smi_state.cc
+++ b/sw/nic/gpuagent/api/smi/gimamdsmi/smi_state.cc
@@ -715,6 +715,29 @@ smi_state::init(aga_api_init_params_t *init_params) {
     spawn_event_monitor_thread_();
     // spawn watcher thread
     spawn_watcher_thread_();
+    initialized_ = true;
+    return SDK_RET_OK;
+}
+
+sdk_ret_t
+smi_state::teardown (void)
+{
+    amdsmi_status_t status;
+
+    if (!initialized_) {
+        return SDK_RET_OK;
+    }
+    // stop the watcher thread before shutting down the SMI library to
+    // avoid racing with the watcher timer callback which calls SMI APIs
+    if (watcher_thread_) {
+        watcher_thread_->stop();
+        watcher_thread_->wait();
+    }
+    status = amdsmi_shut_down();
+    if (unlikely(status != AMDSMI_STATUS_SUCCESS)) {
+        AGA_TRACE_ERR("Failed to shutdown amd smi library, err {}", status);
+        return amdsmi_ret_to_sdk_ret(status);
+    }
     return SDK_RET_OK;
 }
 

--- a/sw/nic/gpuagent/api/smi/smi.cc
+++ b/sw/nic/gpuagent/api/smi/smi.cc
@@ -29,11 +29,15 @@ namespace aga {
 sdk_ret_t
 smi_init (aga_api_init_params_t *init_params)
 {
-    sdk_ret_t ret;
+    // initialize SMI library
+    return g_smi_state.init(init_params);
+}
 
-    // initialize rocm-smi library
-    ret = g_smi_state.init(init_params);
-    return ret;
+sdk_ret_t
+smi_teardown (void)
+{
+    // teardown SMI library
+    return g_smi_state.teardown();
 }
 
 }    // namespace aga

--- a/sw/nic/gpuagent/api/smi/smi_api.hpp
+++ b/sw/nic/gpuagent/api/smi/smi_api.hpp
@@ -54,6 +54,10 @@ namespace aga {
 /// \return     SDK_RET_OK or error code in case of failure
 sdk_ret_t smi_init(aga_api_init_params_t *init_params);
 
+/// \brief    teardown smi layer
+/// \return     SDK_RET_OK or error code in case of failure
+sdk_ret_t smi_teardown(void);
+
 /// \brief    fill gpu object config specification
 /// \param[in] handle    GPU handle
 /// \param[out] spec    operational status to be filled

--- a/sw/nic/gpuagent/api/smi/smi_api_mock.cc
+++ b/sw/nic/gpuagent/api/smi/smi_api_mock.cc
@@ -623,6 +623,12 @@ spawn_event_monitor_thread (void)
 }
 
 sdk_ret_t
+smi_teardown (void)
+{
+    return SDK_RET_OK;
+}
+
+sdk_ret_t
 smi_init (aga_api_init_params_t *init_params)
 {
     // spawn event monitor thread

--- a/sw/nic/gpuagent/api/smi/smi_state.hpp
+++ b/sw/nic/gpuagent/api/smi/smi_state.hpp
@@ -58,6 +58,8 @@ public:
     /// \brief constructor
     smi_state() {
         num_gpu_ = 0;
+        initialized_ = false;
+        watcher_thread_ = NULL;
     }
 
     /// \brief    destructor
@@ -67,6 +69,10 @@ public:
     /// \param[in] init_params    initialization parameters
     /// \return SDK_RET_OK or error status in case of failure
     sdk_ret_t init(aga_api_init_params_t *init_params);
+
+    /// \brief    teardown routine
+    /// \return SDK_RET_OK or error status in case of failure
+    sdk_ret_t teardown(void);
 
     /// \brief    event database and monitoring infra initialization
     /// \return SDK_RET_OK or error status in case of failure
@@ -170,6 +176,8 @@ private:
                   aga_gpu_handle_t gpu_handle, aga_gpu_watch_db_t *watch_db);
 
 private:
+    /// initialization state
+    bool initialized_;
     /// no. of GPUs in the system
     uint32_t num_gpu_;
     /// gpu handles

--- a/sw/nic/gpuagent/main.cc
+++ b/sw/nic/gpuagent/main.cc
@@ -31,6 +31,7 @@ limitations under the License.
 #include <thread>
 #include <iostream>
 #include <fstream>
+#include <pthread.h>
 #include <signal.h>
 #include <cerrno>
 #include <cstring>
@@ -44,6 +45,7 @@ limitations under the License.
 #include "nic/sdk/include/sdk/assert.hpp"
 #include "nic/gpuagent/include/globals.hpp"
 #include "nic/gpuagent/init.hpp"
+#include "nic/gpuagent/api/include/aga_init.hpp"
 #include "nic/gpuagent/svc/gpu.hpp"
 
 using grpc::Channel;
@@ -82,14 +84,36 @@ clean_unix_socket (const std::string& socket_path)
     unlink(socket_path.c_str());
 }
 
-/// \brief    signal handler for cleanup
+/// \brief    dedicated thread that waits for termination signals and
+///           performs cleanup in normal thread context (async-signal-safe)
 static void
-signal_handler (int signum)
+signal_wait_thread (void)
 {
+    int sig;
+    sigset_t sigset;
+
+    sigemptyset(&sigset);
+    sigaddset(&sigset, SIGTERM);
+    sigaddset(&sigset, SIGINT);
+    sigaddset(&sigset, SIGABRT);
+    sigaddset(&sigset, SIGQUIT);
+    sigaddset(&sigset, SIGHUP);
+    // block until a signal arrives
+    sigwait(&sigset, &sig);
+    // cleanup api layer
+    aga_api_teardown();
+    // cleanup unix socket if used
     if (!g_socket_path.empty()) {
         clean_unix_socket(g_socket_path);
     }
-    exit(0);
+    // restore default handler, unblock the signal in this thread
+    // (sigwait dequeues but does not unblock), then re-raise so the
+    // process terminates with the correct signal/exit status
+    signal(sig, SIG_DFL);
+    sigemptyset(&sigset);
+    sigaddset(&sigset, sig);
+    pthread_sigmask(SIG_UNBLOCK, &sigset, NULL);
+    raise(sig);
 }
 
 /// \brief    prepare Unix socket for gRPC server
@@ -175,8 +199,9 @@ prepare_unix_socket (const std::string& socket_path)
 int
 main (int argc, char **argv)
 {
-    int oc;
+    int oc, rv;
     sdk_ret_t ret;
+    sigset_t sigset;
     struct in6_addr ip_addr;
     std::string grpc_server;
     std::string grpc_server_ip;
@@ -264,6 +289,20 @@ main (int argc, char **argv)
     strncpy(init_params.grpc_server, grpc_server.c_str(),
             AGA_GRPC_SERVER_STR_LEN);
     init_params.grpc_server[AGA_GRPC_SERVER_STR_LEN - 1] = '\0';
+    // block termination signals in all threads so the dedicated
+    // signal-wait thread can handle them in normal context
+    sigemptyset(&sigset);
+    sigaddset(&sigset, SIGTERM);
+    sigaddset(&sigset, SIGINT);
+    sigaddset(&sigset, SIGABRT);
+    sigaddset(&sigset, SIGQUIT);
+    sigaddset(&sigset, SIGHUP);
+    rv = pthread_sigmask(SIG_BLOCK, &sigset, NULL);
+    if (rv) {
+        fprintf(stderr, "Failed to block signals, err %d\n", rv);
+    }
+    // spawn signal-wait thread for async-signal-safe cleanup
+    std::thread(signal_wait_thread).detach();
     // handle Unix socket setup before initialization
     if (use_unix_socket) {
         // prepare Unix socket (check for existing instances, cleanup, etc.)
@@ -273,9 +312,6 @@ main (int argc, char **argv)
         }
         // save socket path for cleanup
         g_socket_path = grpc_unix_socket;
-        // register signal handlers for cleanup
-        signal(SIGINT, signal_handler);
-        signal(SIGTERM, signal_handler);
     } else {
         // cleanup any existing Unix socket on TCP initialization
         clean_unix_socket(AGA_DEFAULT_UNIX_SOCKET_PATH);


### PR DESCRIPTION
…GHUP

Replace simple signal_handler (which called exit()) with a sigwait thread that calls aga_api_teardown() → smi_teardown() → amdsmi_shut_down() for clean resource release before process exit. Cleans up Unix socket path and re-raises signal with default handler for correct exit status.

Port of pensando/sw PR #115319 (UAL changes excluded).

```
$   gpuctl show gpu -s --node-svc-socket /tmp/gpuagent-host.sock

GPU id                                 : 87ff74a0-0000-1000-8020-c0a798ed7734 (0)
Index                                  : 0
KFD id                                 : 59876
DRM render id                          : 144
DRM card id                            : 17
Virtualization mode                    : none
GPU handle                             : 0x3d48110
Card series                            : Aqua Vanjaram [Instinct MI300A]
Card vendor                            : Advanced Micro Devices, Inc. [AMD/ATI]
Driver version                         : 6.14.14
Partition Id                           : 0
Firmware versions:
  CP_MEC1 firmware version             : 186
  CP_MEC2 firmware version             : 186
  RLC firmware version                 : 69
  SDMA0 firmware version               : 24
```

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
