### PR TITLE
fix(cve): bump Go toolchain 1.25.8 -> 1.25.11

### DIFF
--- a/sw/nic/gpuagent/Makefile
+++ b/sw/nic/gpuagent/Makefile
@@ -176,7 +176,7 @@ $(TARGET)_gim: build-libs gogo-protos gen-protos $(OBJ_GIM)
 .PHONY: mod
 mod:
 	@go mod tidy
-	@go mod edit -go=1.25.8
+	@go mod edit -go=1.25.11
 	#CVE-2024-24790 - gpuctl
 	@go mod edit -replace golang.org/x/net@v0.30.0=golang.org/x/net@v0.38.0
 	#CVE-2026-33186

--- a/sw/nic/gpuagent/go.mod
+++ b/sw/nic/gpuagent/go.mod
@@ -1,6 +1,6 @@
 module github.com/ROCm/gpu-agent/sw/nic/gpuagent
 
-go 1.25.8
+go 1.25.11
 
 require (
 	github.com/gogo/protobuf v1.3.2

--- a/tools/build-container/Dokerfile.rhel9
+++ b/tools/build-container/Dokerfile.rhel9
@@ -28,9 +28,9 @@ RUN dnf install -y --allowerasing \
 
 RUN yum install -y sudo
 
-RUN wget https://go.dev/dl/go1.25.8.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.25.8.linux-amd64.tar.gz && \
-    rm -f go1.25.8.linux-amd64.tar.gz
+RUN wget https://go.dev/dl/go1.25.11.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.25.11.linux-amd64.tar.gz && \
+    rm -f go1.25.11.linux-amd64.tar.gz
 
 ENV PATH=$PATH:/usr/local/go/bin:/root/go/bin
 ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH

--- a/tools/build-container/Dokerfile.ubu2204
+++ b/tools/build-container/Dokerfile.ubu2204
@@ -30,9 +30,9 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /usr/src/github.com/Rocm/gpu-agent/
 
-RUN wget https://go.dev/dl/go1.25.8.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.25.8.linux-amd64.tar.gz && \
-    rm -f go1.25.8.linux-amd64.tar.gz
+RUN wget https://go.dev/dl/go1.25.11.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.25.11.linux-amd64.tar.gz && \
+    rm -f go1.25.11.linux-amd64.tar.gz
 
 ADD ./entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
## Summary

Closes 11 HIGH stdlib CVEs reported by trivy against the `gpuctl` binary by bumping the Go toolchain from 1.25.8 to 1.25.11. Also closes UNKNOWN CVE-2026-27145.

CVEs addressed:
CVE-2026-32280, CVE-2026-32281, CVE-2026-32283, CVE-2026-33811, CVE-2026-33814, CVE-2026-39820, CVE-2026-39823, CVE-2026-39825, CVE-2026-39826, CVE-2026-39836, CVE-2026-42499, CVE-2026-27145.

## Changes

- `sw/nic/gpuagent/go.mod` — `go 1.25.8` → `go 1.25.11`
- `sw/nic/gpuagent/Makefile` — `mod` target pins `-go=1.25.11`
- `tools/build-container/Dokerfile.rhel9` — Go tarball URL `go1.25.8` → `go1.25.11` (3 occurrences)
- `tools/build-container/Dokerfile.ubu2204` — same (3 occurrences)

No third-party module changes. `go.sum` and vendor tree unchanged (stdlib-only patch bump).

## Test plan

- [x] `make build-container` (rhel9 + ubuntu builders rebuilt with Go 1.25.11)
- [x] `make -C sw/nic/gpuagent mod` succeeds inside new builder
- [x] `make gpuagent` succeeds (gpuagent, gpuagent_gim, gpuagent_mock, gpuctl)
- [x] `docker run --rm gpuagent-builder-rhel:9 /usr/local/go/bin/go version` → `go1.25.11 linux/amd64`
- [x] `trivy rootfs --severity HIGH,CRITICAL sw/nic/build/x86_64/sim/bin/gpuctl` → 0 vulnerabilities