### PR TITLE
fix(smi): warm-up read to defeat RDNA4 cold-read gfx_activity artifact

### DIFF
--- a/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
+++ b/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
@@ -144,6 +144,12 @@ smi_gpu_fill_spec (aga_gpu_handle_t gpu_handle, aga_gpu_spec_t *spec)
     uint32_t sensor_idx[AGA_GPU_MAX_POWER_CAP_SENSOR];
     amdsmi_power_cap_type_t sensor_types[AGA_GPU_MAX_POWER_CAP_SENSOR];
 
+    // warm-up read to settle the RDNA4 cold-read gfx_activity artifact
+    amdsmi_ret = amdsmi_get_gpu_metrics_info(gpu_handle, &metrics_info);
+    if (unlikely(amdsmi_ret != AMDSMI_STATUS_SUCCESS)) {
+        AGA_TRACE_ERR("Warm-up GPU metrics read failed for GPU {}, err {}",
+                      gpu_handle, amdsmi_ret);
+    }
     // re-fetch gpu metrics for this GPU handle
     amdsmi_ret = amdsmi_get_gpu_metrics_info(gpu_handle, &metrics_info);
     {


### PR DESCRIPTION
On RDNA4 (Navi4x) the first amdsmi_get_gpu_metrics_info() after a GPU has been idle in a runtime-PM low-power state returns a spurious-high average_gfx_activity that settles to the true value on the very next read. Since both gpuctl and DME read through gpu_entry::read() -> smi_gpu_fill_spec(), the cold value leaks into exported metrics as phantom GPU utilization at idle.

Add a throwaway warm-up amdsmi_get_gpu_metrics_info() immediately before the authoritative read in smi_gpu_fill_spec(), so the cached value is always the warm/settled second read. Cost is <1ms per poll and is harmless on platforms without the artifact (it returns the same value twice).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

```
 ┌───────┬─────────────────────────────┬──────────────────────────┐
  │ round │ OLD (no-fix, :5008) max gfx │ NEW (fix, :5007) max gfx │                                        
  ├───────┼─────────────────────────────┼──────────────────────────┤
  │ 1     │ 78                          │ 6                        │
  ├───────┼─────────────────────────────┼──────────────────────────┤
  │ 2     │ 3                           │ 6                        │
  ├───────┼─────────────────────────────┼──────────────────────────┤
  │ 3     │ 76                          │ 6                        │
  ├───────┼─────────────────────────────┼──────────────────────────┤
  │ 4     │ 3                           │ 6                        │
  ├───────┼─────────────────────────────┼──────────────────────────┤
  │ 5     │ 3                           │ 5                        │
  ├───────┼─────────────────────────────┼──────────────────────────┤
  │ 6     │ 3                           │ 6                        │
  └───────┴─────────────────────────────┴──────────────────────────┘

```
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
