### PR TITLE
gimamdsmi: fix AGA_SMI_SESSION_GUARD macro indentation

### DIFF
--- a/sw/nic/gpuagent/api/smi/gimamdsmi/smi_api.cc
+++ b/sw/nic/gpuagent/api/smi/gimamdsmi/smi_api.cc
@@ -63,24 +63,25 @@ namespace aga {
 ///         `caller_handle` and a `const aga_obj_key_t *gpu_key`):
 ///             AGA_SMI_SESSION_GUARD(gpu_key, caller_handle);
 ///             // ... amdsmi calls now use the refreshed local `gpu_handle` ...
-#define AGA_SMI_SESSION_GUARD(gpu_key_ptr, caller_handle)                    \
-    std::unique_ptr<smi_session> _smi_sess_;                                 \
-    aga_gpu_handle_t gpu_handle = (caller_handle);                           \
-    if (g_smi_state.lazy_init()) {                                           \
-        _smi_sess_ = std::make_unique<smi_session>();                        \
-        if (!_smi_sess_->ok()) {                                             \
-            AGA_TRACE_ERR("Per-request smi_session init failed");            \
-            return _smi_sess_->ret();                                        \
-        }                                                                    \
-        if ((gpu_key_ptr) != NULL) {                                         \
-            amdsmi_status_t _us = amdsmi_get_processor_handle_from_uuid(     \
-                                      (gpu_key_ptr)->str(), &gpu_handle);   \
-            if (_us != AMDSMI_STATUS_SUCCESS) {                              \
-                AGA_TRACE_ERR("gpu_key->handle resolve failed for {}, "      \
-                              "err {}", (gpu_key_ptr)->str(), _us);          \
-                return amdsmi_ret_to_sdk_ret(_us);                           \
-            }                                                                \
-        }                                                                    \
+#define AGA_SMI_SESSION_GUARD(gpu_key_ptr, caller_handle)                  \
+    std::unique_ptr<smi_session> _smi_sess_;                               \
+    aga_gpu_handle_t gpu_handle = (caller_handle);                         \
+    if (g_smi_state.lazy_init()) {                                         \
+        _smi_sess_ = std::make_unique<smi_session>();                      \
+        if (!_smi_sess_->ok()) {                                           \
+            AGA_TRACE_ERR("Per-request smi_session init failed");          \
+            return _smi_sess_->ret();                                      \
+        }                                                                  \
+        if ((gpu_key_ptr) != NULL) {                                       \
+            amdsmi_status_t _us =                                          \
+                amdsmi_get_processor_handle_from_uuid(                     \
+                    (gpu_key_ptr)->str(), &gpu_handle);                    \
+            if (_us != AMDSMI_STATUS_SUCCESS) {                            \
+                AGA_TRACE_ERR("gpu_key->handle resolve failed for {}, "    \
+                              "err {}", (gpu_key_ptr)->str(), _us);        \
+                return amdsmi_ret_to_sdk_ret(_us);                         \
+            }                                                              \
+        }                                                                  \
     }
 
 /// \brief struct to be used as ctxt when walking GPU db to build topology

--- a/sw/nic/gpuagent/api/smi/gimamdsmi/smi_api.cc
+++ b/sw/nic/gpuagent/api/smi/gimamdsmi/smi_api.cc
@@ -63,25 +63,27 @@ namespace aga {
 ///         `caller_handle` and a `const aga_obj_key_t *gpu_key`):
 ///             AGA_SMI_SESSION_GUARD(gpu_key, caller_handle);
 ///             // ... amdsmi calls now use the refreshed local `gpu_handle` ...
-#define AGA_SMI_SESSION_GUARD(gpu_key_ptr, caller_handle)                      \
-            std::unique_ptr<smi_session> _smi_sess_;                           \
-            aga_gpu_handle_t gpu_handle = (caller_handle);                     \
-            if (g_smi_state.lazy_init()) {                                     \
-                _smi_sess_ = std::make_unique<smi_session>();                  \
-                if (!_smi_sess_->ok()) {                                       \
-                    AGA_TRACE_ERR("Per-request smi_session init failed");      \
-                    return _smi_sess_->ret();                                  \
-                }                                                              \
-                if ((gpu_key_ptr) != NULL) {                                   \
-                    amdsmi_status_t _us =                                      \
-                        amdsmi_get_processor_handle_from_uuid(                 \
-                            (gpu_key_ptr)->str(), &gpu_handle);                \
-                    if (_us != AMDSMI_STATUS_SUCCESS) {                        \
-                        AGA_TRACE_ERR("gpu_key->handle resolve failed for {}, "\
-                                      "err {}", (gpu_key_ptr)->str(), _us);   \
-                        return amdsmi_ret_to_sdk_ret(_us);                     \
-                    }                                                          \
-                }                                                              \
+#define AGA_SMI_SESSION_GUARD(gpu_key_ptr, caller_handle)            \
+            std::unique_ptr<smi_session> _smi_sess_;                 \
+            aga_gpu_handle_t gpu_handle = (caller_handle);           \
+            if (g_smi_state.lazy_init()) {                           \
+                _smi_sess_ = std::make_unique<smi_session>();        \
+                if (!_smi_sess_->ok()) {                             \
+                    AGA_TRACE_ERR("Per-request smi_session "         \
+                                  "init failed");                    \
+                    return _smi_sess_->ret();                        \
+                }                                                    \
+                if ((gpu_key_ptr) != NULL) {                         \
+                    amdsmi_status_t _us =                            \
+                        amdsmi_get_processor_handle_from_uuid(       \
+                            (gpu_key_ptr)->str(), &gpu_handle);      \
+                    if (_us != AMDSMI_STATUS_SUCCESS) {              \
+                        AGA_TRACE_ERR("gpu_key->handle resolve "     \
+                                      "failed for {}, err {}",       \
+                                      (gpu_key_ptr)->str(), _us);    \
+                        return amdsmi_ret_to_sdk_ret(_us);           \
+                    }                                                \
+                }                                                    \
             }
 
 /// \brief struct to be used as ctxt when walking GPU db to build topology

--- a/sw/nic/gpuagent/api/smi/gimamdsmi/smi_api.cc
+++ b/sw/nic/gpuagent/api/smi/gimamdsmi/smi_api.cc
@@ -63,26 +63,26 @@ namespace aga {
 ///         `caller_handle` and a `const aga_obj_key_t *gpu_key`):
 ///             AGA_SMI_SESSION_GUARD(gpu_key, caller_handle);
 ///             // ... amdsmi calls now use the refreshed local `gpu_handle` ...
-#define AGA_SMI_SESSION_GUARD(gpu_key_ptr, caller_handle)                  \
-    std::unique_ptr<smi_session> _smi_sess_;                               \
-    aga_gpu_handle_t gpu_handle = (caller_handle);                         \
-    if (g_smi_state.lazy_init()) {                                         \
-        _smi_sess_ = std::make_unique<smi_session>();                      \
-        if (!_smi_sess_->ok()) {                                           \
-            AGA_TRACE_ERR("Per-request smi_session init failed");          \
-            return _smi_sess_->ret();                                      \
-        }                                                                  \
-        if ((gpu_key_ptr) != NULL) {                                       \
-            amdsmi_status_t _us =                                          \
-                amdsmi_get_processor_handle_from_uuid(                     \
-                    (gpu_key_ptr)->str(), &gpu_handle);                    \
-            if (_us != AMDSMI_STATUS_SUCCESS) {                            \
-                AGA_TRACE_ERR("gpu_key->handle resolve failed for {}, "    \
-                              "err {}", (gpu_key_ptr)->str(), _us);        \
-                return amdsmi_ret_to_sdk_ret(_us);                         \
-            }                                                              \
-        }                                                                  \
-    }
+#define AGA_SMI_SESSION_GUARD(gpu_key_ptr, caller_handle)                      \
+            std::unique_ptr<smi_session> _smi_sess_;                           \
+            aga_gpu_handle_t gpu_handle = (caller_handle);                     \
+            if (g_smi_state.lazy_init()) {                                     \
+                _smi_sess_ = std::make_unique<smi_session>();                  \
+                if (!_smi_sess_->ok()) {                                       \
+                    AGA_TRACE_ERR("Per-request smi_session init failed");      \
+                    return _smi_sess_->ret();                                  \
+                }                                                              \
+                if ((gpu_key_ptr) != NULL) {                                   \
+                    amdsmi_status_t _us =                                      \
+                        amdsmi_get_processor_handle_from_uuid(                 \
+                            (gpu_key_ptr)->str(), &gpu_handle);                \
+                    if (_us != AMDSMI_STATUS_SUCCESS) {                        \
+                        AGA_TRACE_ERR("gpu_key->handle resolve failed for {}, "\
+                                      "err {}", (gpu_key_ptr)->str(), _us);   \
+                        return amdsmi_ret_to_sdk_ret(_us);                     \
+                    }                                                          \
+                }                                                              \
+            }
 
 /// \brief struct to be used as ctxt when walking GPU db to build topology
 typedef struct gpu_topo_walk_ctxt_s {


### PR DESCRIPTION
## Summary

Follow-up to #67 — addresses [sarat-k's review comment](https://github.com/ROCm/gpu-agent/pull/67#discussion_r3373396909) that the macro indentation in `smi_api.cc` was off.

- Re-align trailing line-continuation backslashes in the `AGA_SMI_SESSION_GUARD` macro to a single column
- Break `amdsmi_get_processor_handle_from_uuid(...)` so its arguments sit under the opening paren instead of hanging mid-line under the function name

No functional change — formatting only.

## Test plan

- [x] Visual diff inspection
- [ ] Builds clean inside the gpuagent builder (macro is expanded by every `smi_api.cc` entry point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)