### PR TITLE
GPUOP-907: fix gpuagent SIGSEGV on MI350P from clock freq OOB read

### DIFF
--- a/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
+++ b/sw/nic/gpuagent/api/smi/amdsmi/smi_api.cc
@@ -528,6 +528,7 @@ smi_fill_clock_status_ (aga_gpu_handle_t gpu_handle,
                         aga_gpu_spec_t *spec, aga_gpu_status_t *status,
                         amdsmi_gpu_metrics_t *metrics_info)
 {
+    uint64_t cur_freq;
     uint32_t clk_cnt = 0;
     amdsmi_status_t amdsmi_ret;
     uint32_t low_freq, high_freq;
@@ -642,10 +643,12 @@ smi_fill_clock_status_ (aga_gpu_handle_t gpu_handle,
     }
     // data fabric clock
     amdsmi_ret = amdsmi_get_clk_freq(gpu_handle, AMDSMI_CLK_TYPE_DF, &freq);
+    cur_freq = current_frequency_hz(&freq);
     if (unlikely(amdsmi_ret != AMDSMI_STATUS_SUCCESS)) {
         AGA_TRACE_ERR("Failed to get data fabric clock frequencies for GPU {}, "
                       "err {}", gpu_handle, amdsmi_ret);
-    } else {
+    } else if (cur_freq != AMDSMI_INVALID_UINT32) {
+        // skip clock types whose current frequency is reported as NA
         low_freq = high_freq = 0;
         clock_status = &status->clock_status[clk_cnt];
         // min and max frequencies are per clock type
@@ -653,17 +656,19 @@ smi_fill_clock_status_ (aga_gpu_handle_t gpu_handle,
                                 &clock_status->low_frequency,
                                 &clock_status->high_frequency);
         clock_status->clock_type = AGA_GPU_CLOCK_TYPE_FABRIC;
-        clock_status->frequency = freq.frequency[freq.current]/1000000;
+        clock_status->frequency = cur_freq / 1000000;
         clock_status->deep_sleep =
             (clock_status->frequency < clock_status->low_frequency);
         clk_cnt++;
     }
     // DCE clock
     amdsmi_ret = amdsmi_get_clk_freq(gpu_handle, AMDSMI_CLK_TYPE_DCEF, &freq);
+    cur_freq = current_frequency_hz(&freq);
     if (unlikely(amdsmi_ret != AMDSMI_STATUS_SUCCESS)) {
         AGA_TRACE_ERR("Failed to get DCE clock frequencies for GPU {}, err {}",
                       gpu_handle, amdsmi_ret);
-    } else {
+    } else if (cur_freq != AMDSMI_INVALID_UINT32) {
+        // skip clock types whose current frequency is reported as NA
         low_freq = high_freq = 0;
         clock_status = &status->clock_status[clk_cnt];
         // min and max frequencies are per clock type
@@ -671,17 +676,19 @@ smi_fill_clock_status_ (aga_gpu_handle_t gpu_handle,
                                 &clock_status->low_frequency,
                                 &clock_status->high_frequency);
         clock_status->clock_type = AGA_GPU_CLOCK_TYPE_DCE;
-        clock_status->frequency = freq.frequency[freq.current]/1000000;
+        clock_status->frequency = cur_freq / 1000000;
         clock_status->deep_sleep =
             (clock_status->frequency < clock_status->low_frequency);
         clk_cnt++;
     }
     // PCIe clock
     amdsmi_ret = amdsmi_get_clk_freq(gpu_handle, AMDSMI_CLK_TYPE_PCIE, &freq);
+    cur_freq = current_frequency_hz(&freq);
     if (unlikely(amdsmi_ret != AMDSMI_STATUS_SUCCESS)) {
         AGA_TRACE_ERR("Failed to get PCIe clock frequencies for GPU {}, err {}",
                       gpu_handle, amdsmi_ret);
-    } else {
+    } else if (cur_freq != AMDSMI_INVALID_UINT32) {
+        // skip clock types whose current frequency is reported as NA
         low_freq = high_freq = 0;
         clock_status = &status->clock_status[clk_cnt];
         // min and max frequencies are per clock type
@@ -689,7 +696,7 @@ smi_fill_clock_status_ (aga_gpu_handle_t gpu_handle,
                                 &clock_status->low_frequency,
                                 &clock_status->high_frequency);
         clock_status->clock_type = AGA_GPU_CLOCK_TYPE_PCIE;
-        clock_status->frequency = freq.frequency[freq.current]/1000000;
+        clock_status->frequency = cur_freq / 1000000;
         clock_status->deep_sleep =
             (clock_status->frequency < clock_status->low_frequency);
         clk_cnt++;

--- a/sw/nic/gpuagent/api/smi/amdsmi/smi_utils.hpp
+++ b/sw/nic/gpuagent/api/smi/amdsmi/smi_utils.hpp
@@ -46,9 +46,10 @@ static inline void
 find_low_high_frequency (amdsmi_frequencies_t *freq,
                          uint32_t *min, uint32_t *max)
 {
-    // create a vector of the valid frequencies
-    std::vector<uint64_t> f(freq->frequency,
-                            freq->frequency + freq->num_supported);
+    // clamp num_supported to the array bound before building the vector
+    uint32_t n = (freq->num_supported < AMDSMI_MAX_NUM_FREQUENCIES) ?
+                      freq->num_supported : AMDSMI_MAX_NUM_FREQUENCIES;
+    std::vector<uint64_t> f(freq->frequency, freq->frequency + n);
 
     // sort vector
     std::sort(f.begin(), f.end());
@@ -74,6 +75,24 @@ find_low_high_frequency (amdsmi_frequencies_t *freq,
         *max = (uint32_t)(f[f.size() - 1]/1000000);
     }
     return;
+}
+
+/// \brief return current raw frequency in Hz, clamping an out-of-bounds index
+/// \param[in] freq    frequencies struct from amdsmi
+/// \return    current frequency in Hz; 0 when no supported frequencies,
+///            else the first entry if current is out of range
+static inline uint64_t
+current_frequency_hz (amdsmi_frequencies_t *freq)
+{
+    uint32_t n, idx;
+
+    if (freq->num_supported == 0) {
+        return 0;
+    }
+    n = (freq->num_supported < AMDSMI_MAX_NUM_FREQUENCIES) ?
+             freq->num_supported : AMDSMI_MAX_NUM_FREQUENCIES;
+    idx = (freq->current < n) ? freq->current : 0;
+    return freq->frequency[idx];
 }
 
 /// \brief convert amdsmi virtualization mode to aga vritualization mode


### PR DESCRIPTION
smi_fill_clock_status_ indexed freq.frequency[freq.current] without bounds-checking. On gfx950 (MI350P) amdsmi returns SUCCESS with a garbage freq.current / num_supported for the DF/DCEF/PCIe clock types, so the read goes past the fixed-size frequency[] array and SIGSEGVs the grpcpp_sync_ser thread (ip 0x116384f) on every `gpuctl show gpu`. MI300/gfx942 returns a valid in-bounds index so the bug never fires there.

- add current_frequency_mhz() helper that clamps freq.current to a valid index before indexing frequency[]
- clamp num_supported to AMDSMI_MAX_NUM_FREQUENCIES in find_low_high_frequency() before constructing the vector

Validated on MI350P: baseline SIGSEGVs at ip 0x116384f; fixed binary no longer faults in the clock path (gdb confirms smi_fill_clock_status_ is clear).

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
