### PR TITLE
gimamdsmi: fix aga_obj_key_t::str() UUID truncation from sizeof(char*)

### DIFF
--- a/sw/nic/gpuagent/api/include/base.hpp
+++ b/sw/nic/gpuagent/api/include/base.hpp
@@ -122,7 +122,8 @@ struct aga_obj_key_s {
         buf[23] = '-';
         for (uint32_t i = 0; i < 6; i++) {
             uint32_t off = 24 + (i << 1);
-            snprintf(&buf[off], sizeof(buf) - off,"%02x", id[10 + i] & 0xFF);
+            snprintf(&buf[off], (OBJ_MAX_KEY_STR_LEN + 1) - off, "%02x",
+                     id[10 + i] & 0xFF);
         }
         buf[OBJ_MAX_KEY_STR_LEN] = '\0';
         return buf;


### PR DESCRIPTION
str() used sizeof(buf) as the snprintf bound while buf is a char*, so the bound was 8 (pointer size), not the buffer length. For the MAC-tail loop (off>=24) the expression sizeof(buf)-off underflows to a size_t far above INT_MAX, which glibc snprintf rejects, so the final 12-hex UUID group is never written. str() returns a truncated 25-char UUID.

This is normally harmless (str() is used for logging) but under AGA_SMI_LAZY_INIT=1 the per-request AGA_SMI_SESSION_GUARD re-resolves the GPU handle via amdsmi_get_processor_handle_from_uuid(gpu_key->str()). The GIM amdsmi lib's is_uuid_valid() rejects the truncated string with AMDSMI_STATUS_INVAL, so the guard bails before filling any spec and before the virtualization-mode read. Net effect on a GIM/SR-IOV host: deployment_mode reported as baremetal and all GPU metrics dropped.

Use OBJ_MAX_KEY_STR_LEN + 1 as the bound. Validated on leto MI210 GIM host with AGA_SMI_LAZY_INIT=1: resolve failures 14->0, full 36-char UUID emitted, deployment_mode=hypervisor, full metric set restored.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
