### PR TITLE
[KUBE-54] gimamdsmi: gate watcher device polling on watch subscribers

### DIFF
--- a/sw/nic/gpuagent/api/smi/gimamdsmi/smi_state.cc
+++ b/sw/nic/gpuagent/api/smi/gimamdsmi/smi_state.cc
@@ -561,6 +561,11 @@ watch_timer_cb_ (event::timer_t *timer)
     aga_task_spec_t task_spec = {};
     static uint16_t timer_ticks = 0;
 
+    // only start updating watch fields once at least one client has subscribed
+    // to a watch group
+    if (!g_smi_state.any_watch_group_subscribed()) {
+        return;
+    }
     // get latest values of all watch fields
     g_smi_state.watcher_update_watch_db(&task_spec.watch_db);
 


### PR DESCRIPTION
The GIM watcher's timer callback opened /dev/gim-smi0 and issued full-access SMI reads every tick unconditionally, even with no GPUWatch subscribers -- a permanent 1Hz gim poll with no consumer, and the exposure surface for the KUBE-54 hang (a wedged gim ioctl in this path livelocks the caller in-kernel). Port the subscriber guard the baremetal amdsmi path already has.

Validated by strace on MI300X (GIM): patched build opens the device only at startup discovery, zero periodic opens after; stock polls gim-smi0 ~1Hz indefinitely.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
